### PR TITLE
Top card flips for explore helper

### DIFF
--- a/src/ExploreHelper.ttslua
+++ b/src/ExploreHelper.ttslua
@@ -214,6 +214,7 @@ function takeEncounter()
       end
       local pos = self.positionToWorld(exploreDeckOffset)
       deckLib.placeOrMergeIntoDeck(card, pos)
+      if encounterDeckObjects.topCard then mythosAreaApi.flipTopCardFromDeck() end
       shuffleBack(true)
     else
       broadcastToAll("Encounter deck is empty", "Red")


### PR DESCRIPTION
If the top card is revealed after shuffling in the top card of the encounter deck.