### PR TITLE
Bug fix: Tekeli-li helper with one card remaining

### DIFF
--- a/src/EdgeOfTheEarth/TekeliliHelper.ttslua
+++ b/src/EdgeOfTheEarth/TekeliliHelper.ttslua
@@ -232,7 +232,11 @@ function drawTekelili(player)
   local matColor = playermatApi.getMatColor(player.color)
   local pos = playermatApi.getEncounterCardDrawPosition(matColor, false)
   local rot = playermatApi.returnRotation(matColor)
-  deckLib.placeOrMergeIntoDeck(deck.takeObject(), Vector(pos), rot)
+  if deck.type == "Card" then
+    deckLib.placeOrMergeIntoDeck(deck, Vector(pos), rot)
+  else
+    deckLib.placeOrMergeIntoDeck(deck.takeObject(), Vector(pos), rot)
+  end
 end
 
 -- shuffles a tekeli-li card into the deck of the requesting player
@@ -244,8 +248,12 @@ function shuffleTekelili(player)
   local pos = playermatApi.getDrawPosition(matColor)
   local rot = playermatApi.returnRotation(matColor)
   rot = rot:setAt("z", 180)
-  deckLib.placeOrMergeIntoDeck(deck.takeObject(), Vector(pos), rot)
-
+  if deck.type == "Card" then
+    deckLib.placeOrMergeIntoDeck(deck, Vector(pos), rot)
+  else
+    deckLib.placeOrMergeIntoDeck(deck.takeObject(), Vector(pos), rot)
+  end
+  
   -- shuffle deck (after a short delay to make sure the card is in it)
   Wait.time(function()
     local drawDeck = playermatApi.getDeckAreaObjects(matColor).draw


### PR DESCRIPTION
Fixes the 'Draw to my playmat' and 'Shuffle into my deck' buttons to behave as expected