### PR TITLE
cross platform updates

### DIFF
--- a/.vscode/build_saved_object.py
+++ b/.vscode/build_saved_object.py
@@ -22,10 +22,19 @@ def build_saved_object(input_file):
         return
 
     # Construct output path
+    if sys.platform == "darwin": # macOS
+        output_file = os.path.join(
+            os.path.expanduser("~"),
+            "Library",
+        )
+    else: # windows
+        output_file = os.path.join(
+            os.environ["USERPROFILE"],
+            "Documents",
+            "My Games",
+        )
     output_file = os.path.join(
-        os.environ["USERPROFILE"],
-        "Documents",
-        "My Games",
+        f"{output_file}",
         "Tabletop Simulator",
         "Saves",
         "Saved Objects",
@@ -33,19 +42,41 @@ def build_saved_object(input_file):
     )
 
     # Run the go command
-    cmd = [
-        "go",
-        "run",
-        "main.go",
-        "--moddir=C:\\git\\SCED",
-        "--bonusdir=C:\\git\\SCED-downloads",
-        f"--objin={input_file}",
-        f"--objout={output_file}",
-        "--savedobj",
-    ]
-
+    if sys.platform == "darwin": # macOS
+        bonusdir_path = os.path.dirname(os.path.dirname(__file__))
+        moddir_path = os.path.join(os.path.dirname(bonusdir_path), "SCED")
+        cmd = [
+            "go",
+            "run",
+            "main.go",
+            "-moddir",
+            f"{moddir_path}",
+            "-bonusdir",
+            f"{bonusdir_path}",
+            "-objin",
+            f"{input_file}",
+            "-objout",
+            f"{output_file}",
+            "-savedobj",
+        ]
+    else: # windows
+        cmd = [
+            "go",
+            "run",
+            "main.go",
+            "--moddir=C:\\git\\SCED",
+            "--bonusdir=C:\\git\\SCED-downloads",
+            f"--objin={input_file}",
+            f"--objout={output_file}",
+            "--savedobj",
+        ]
+    
     # Execute from the correct directory
-    subprocess.run(cmd, cwd="C:\\git\\TTSModManager")
+    if sys.platform == "darwin": # macOS
+        modManager_path = os.path.join(os.path.dirname(bonusdir_path), "TTSModManager")
+        subprocess.run(cmd, cwd=f"{modManager_path}")
+    else: # windows
+        subprocess.run(cmd, cwd="C:\\git\\TTSModManager")
 
 
 if __name__ == "__main__":

--- a/.vscode/decompose_saved_object.py
+++ b/.vscode/decompose_saved_object.py
@@ -81,10 +81,19 @@ def decompose_saved_object(input_file):
         return
 
     # Construct the saved object path
+    if sys.platform == "darwin": # macOS
+        saved_object = os.path.join(
+            os.path.expanduser("~"),
+            "Library",
+        )
+    else: # windows
+        saved_object = os.path.join(
+            os.environ["USERPROFILE"],
+            "Documents",
+            "My Games",
+        )
     saved_object = os.path.join(
-        os.environ["USERPROFILE"],
-        "Documents",
-        "My Games",
+        f"{saved_object}",
         "Tabletop Simulator",
         "Saves",
         "Saved Objects",
@@ -101,18 +110,37 @@ def decompose_saved_object(input_file):
     output_path = os.path.dirname(input_file)
 
     # Run the go command
-    cmd = [
-        "go",
-        "run",
-        "main.go",
-        "--moddir=C:\\git\\SCED",
-        f"--objin={prepared_saved_object}",
-        f"--objout={output_path}\\",
-        "--reverse",
-    ]
+    if sys.platform == "darwin": # macOS
+        moddir_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "SCED")
+        cmd = [
+            "go",
+            "run",
+            "main.go",
+            "-moddir",
+            f"{moddir_path}",
+            "-objin",
+            f"{prepared_saved_object}",
+            "-objout",
+            f"{output_path}/",
+            "-reverse",
+        ]
+    else: # windows
+        cmd = [
+            "go",
+            "run",
+            "main.go",
+            "--moddir=C:\\git\\SCED",
+            f"--objin={prepared_saved_object}",
+            f"--objout={output_path}\\",
+            "--reverse",
+        ]
 
     # Execute from the correct directory
-    subprocess.run(cmd, cwd="C:\\git\\TTSModManager")
+    if sys.platform == "darwin": # macOS
+        modManager_path = os.path.join(os.path.dirname(moddir_path), "TTSModManager")
+        subprocess.run(cmd, cwd=f"{modManager_path}")
+    else: # windows
+        subprocess.run(cmd, cwd="C:\\git\\TTSModManager")
 
     # Clean up temporary file if created
     if prepared_saved_object != saved_object:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
       "type": "shell",
       "command": "python",
       "args": [
-        "${workspaceFolder}\\.vscode\\build_saved_object.py",
+        "${workspaceFolder}${pathSeparator}.vscode${pathSeparator}build_saved_object.py",
         "${file}"
       ],
       "problemMatcher": [],
@@ -20,7 +20,7 @@
       "type": "shell",
       "command": "python",
       "args": [
-        "${workspaceFolder}\\.vscode\\decompose_saved_object.py",
+        "${workspaceFolder}${pathSeparator}.vscode${pathSeparator}decompose_saved_object.py",
         "${file}"
       ],
       "problemMatcher": [],


### PR DESCRIPTION
Figured this would be cleaner in its own PR. Will attempt to pull changes out of by abyss-helper PR soon.

- tasks.json uses ${pathSeparator} instead of \\
- py objects add in platform conditionals.
- mac uses relative paths in go command (no way to test on windows, so left hardcoded paths)