### PR TITLE
Removed tag from facedown location in Doom of Arkham (1)

### DIFF
--- a/decomposed/campaign/The Drowned City/TheDrownedCity.cthulhu/TheDoomofArkhamPartI.4ffb65/FacedownCards.edef58/TillinghastEsoterica.d21aeb.json
+++ b/decomposed/campaign/The Drowned City/TheDrownedCity.cthulhu/TheDoomofArkhamPartI.4ffb65/FacedownCards.edef58/TillinghastEsoterica.d21aeb.json
@@ -42,7 +42,6 @@
   "Snap": false,
   "Sticky": true,
   "Tags": [
-    "Location",
     "ScenarioCard"
   ],
   "Tooltip": true,


### PR DESCRIPTION
This way the card does not snap while face down, spoiling which card is the location.