### PR TITLE
fix russian devourer below box image, fix parallel investigators & add promos

### DIFF
--- a/decomposed/campaign/Language Pack Russian - Campaigns/LanguagePackRussian-Campaigns.RussianC/NightOfTheZealot.3c77b5/3TheDevourerBelow.2130f0.json
+++ b/decomposed/campaign/Language Pack Russian - Campaigns/LanguagePackRussian-Campaigns.RussianC/NightOfTheZealot.3c77b5/3TheDevourerBelow.2130f0.json
@@ -35,7 +35,7 @@
       "SpecularIntensity": 0,
       "SpecularSharpness": 2
     },
-    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/17180080491045087693/5E5BE6D8D1A0733E232DE0F3C5F3458C59FF7483/",
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/13092474483282434373/5E5BE6D8D1A0733E232DE0F3C5F3458C59FF7483/",
     "MaterialIndex": 3,
     "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
     "TypeIndex": 6

--- a/decomposed/campaign/Language Pack Russian - Campaigns/LanguagePackRussian-Campaigns.RussianC/ReturntotheNightOftheZealot.56270d/3ReturntoTheDevourerBelow.604753.json
+++ b/decomposed/campaign/Language Pack Russian - Campaigns/LanguagePackRussian-Campaigns.RussianC/ReturntotheNightOftheZealot.56270d/3ReturntoTheDevourerBelow.604753.json
@@ -35,7 +35,7 @@
       "SpecularIntensity": 0,
       "SpecularSharpness": 2
     },
-    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/17180080491045087693/5E5BE6D8D1A0733E232DE0F3C5F3458C59FF7483/",
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/13092474483282434373/5E5BE6D8D1A0733E232DE0F3C5F3458C59FF7483/",
     "MaterialIndex": 3,
     "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
     "TypeIndex": 6

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AgnesBaker.25e2db/AgnesBaker.6797bb.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AgnesBaker.25e2db/AgnesBaker.6797bb.json
@@ -1,12 +1,12 @@
 {
-  "CardID": 587403,
+  "CardID": 587405,
   "CustomDeck": {
     "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108622/9BA9D571CE81D39DDED8F6F7573E8676964E7723/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108004/768BB33829A836E2AB5E6775A22271BE77585D4A/",
-      "NumHeight": 3,
-      "NumWidth": 3,
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
+      "NumHeight": 7,
+      "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }
@@ -18,7 +18,7 @@
       "URL": "https://steamusercontent-a.akamaihd.net/ugc/2462982115649258367/C20CC4C299A6FE5F1ECAB968E15BE590337CC019/"
     }
   ],
-  "Description": "The Waitress",
+  "Description": "Чародей.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/AgnesBaker.25e2db/AgnesBaker.6797bb.gmnotes",
   "GUID": "6797bb",
   "HideWhenFaceDown": false,

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AgnesBakerParallel.01b6ef.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AgnesBakerParallel.01b6ef.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5359": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17539460603698058689/5321FBEC5FE7795BB0BABA8BE628ECCD9AFCA4F7/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17593048427525049964/D56FE58541B0B1851D59284E2B7A1A279F8308AD/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/12311436599292946606/7D20A0EF65D7B8F0D17E484835909EB9DFF3447C/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15432700649616750478/6686F8E19B09B13AC95274527F6698E478F8B2FF/",
       "NumHeight": 2,
       "NumWidth": 4,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "01b6ef",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Агнес Бейкер",
+  "Nickname": "Агнес Бейкер (альтернативная)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AgnesBakerParallelBack.909f30.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AgnesBakerParallelBack.909f30.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5359": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17539460603698058689/5321FBEC5FE7795BB0BABA8BE628ECCD9AFCA4F7/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17593048427525049964/D56FE58541B0B1851D59284E2B7A1A279F8308AD/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/12311436599292946606/7D20A0EF65D7B8F0D17E484835909EB9DFF3447C/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15432700649616750478/6686F8E19B09B13AC95274527F6698E478F8B2FF/",
       "NumHeight": 2,
       "NumWidth": 4,
       "Type": 0,
@@ -24,7 +24,7 @@
   "HideWhenFaceDown": false,
   "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
-  "Nickname": "Агнес Бейкер",
+  "Nickname": "Агнес Бейкер (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AgnesBakerParallelFront.02db0a.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AgnesBakerParallelFront.02db0a.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5359": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17539460603698058689/5321FBEC5FE7795BB0BABA8BE628ECCD9AFCA4F7/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17593048427525049964/D56FE58541B0B1851D59284E2B7A1A279F8308AD/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/12311436599292946606/7D20A0EF65D7B8F0D17E484835909EB9DFF3447C/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15432700649616750478/6686F8E19B09B13AC95274527F6698E478F8B2FF/",
       "NumHeight": 2,
       "NumWidth": 4,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "02db0a",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Агнес Бейкер",
+  "Nickname": "Агнес Бейкер (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AshcanPeteParallel.5294c3.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AshcanPeteParallel.5294c3.json
@@ -16,7 +16,7 @@
   "GUID": "5294c3",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Пит Мусорщик",
+  "Nickname": "Пит Мусорщик (альтернативный)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AshcanPeteParallelBack.5294c3.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AshcanPeteParallelBack.5294c3.json
@@ -16,7 +16,7 @@
   "GUID": "5294c3",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Пит Мусорщик",
+  "Nickname": "Пит Мусорщик (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AshcanPeteParallelFront.5294c3.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/AshcanPeteParallelFront.5294c3.json
@@ -16,7 +16,7 @@
   "GUID": "5294c3",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Пит Мусорщик",
+  "Nickname": "Пит Мусорщик (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/CarolynFern.30614e/CarolynFern.9b07a5.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/CarolynFern.30614e/CarolynFern.9b07a5.json
@@ -11,12 +11,11 @@
       "UniqueBack": true
     }
   },
-  "Description": "Promo version",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/CarolynFern.30614e/CarolynFern.9b07a5.gmnotes",
   "GUID": "9b07a5",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Carolyn Fern",
+  "Nickname": "Кэролин Ферн",
   "Tags": [
     "Minicard"
   ],

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/CarolynFern.b03b12/CarolynFernpromoversion.9900a3.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/CarolynFern.b03b12/CarolynFernpromoversion.9900a3.json
@@ -1,22 +1,22 @@
 {
-  "CardID": 273527,
+  "CardID": 587408,
   "CustomDeck": {
-    "2735": {
+    "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845464/80687C9319FA2015F3D9F7CBEB4C55FBF045B27D/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845971/A678BD374EC4DE672206B5EF7EB57DC885BC839C/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
       "NumHeight": 7,
       "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }
   },
-  "Description": "The Psychologist",
+  "Description": "Психолог",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/CarolynFern.b03b12/CarolynFernpromoversion.9900a3.gmnotes",
   "GUID": "9900a3",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Carolyn Fern (promo version)",
+  "Nickname": "Кэролин Ферн (промо версия)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalker.6938eb/DaisyWalker.ac7047.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalker.6938eb/DaisyWalker.ac7047.json
@@ -1,22 +1,22 @@
 {
-  "CardID": 587401,
+  "CardID": 587402,
   "CustomDeck": {
     "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108622/9BA9D571CE81D39DDED8F6F7573E8676964E7723/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108004/768BB33829A836E2AB5E6775A22271BE77585D4A/",
-      "NumHeight": 3,
-      "NumWidth": 3,
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
+      "NumHeight": 7,
+      "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }
   },
-  "Description": "The Librarian",
+  "Description": "Мискатоник.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/DaisyWalker.6938eb/DaisyWalker.ac7047.gmnotes",
   "GUID": "ac7047",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Daisy Walker",
+  "Nickname": "Дейзи Уокер",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalker.bce6a5/DaisyWalker.5fa10d.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalker.bce6a5/DaisyWalker.5fa10d.json
@@ -15,7 +15,7 @@
   "GUID": "5fa10d",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Daisy Walker",
+  "Nickname": "Дэйзи Уокер",
   "Snap": false,
   "Tags": [
     "Minicard"

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalkerParallel.282857.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalkerParallel.282857.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "2702": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14846109107864080525/F4EB9FA9AB31ED89E54DB30F4C7864EF6F401094/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16988189147037424546/DD4AAFF5BCB118E3C577B339C07DA112122A5BB1/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17919946578547348108/3C35A0AFF50890E82C0EB3088F7D256F19086998/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13637224579030300002/F318D03813837E0008B705B4E8F1317AABAE438C/",
       "NumHeight": 2,
       "NumWidth": 3,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "282857",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Дейзи Уокер",
+  "Nickname": "Дейзи Уокер (альтернативная)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalkerParallelBack.2f2e0d.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalkerParallelBack.2f2e0d.json
@@ -3,7 +3,7 @@
   "CustomDeck": {
     "2739": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17532454059782584150/147783FE43E1EDDB7F2802B0CAC434AF6D510D34/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/9263704448478853198/0997B006C797CCE071746277EAFBB28A3FD648D6/",
       "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/12591389111664782579/F63D6D9A21E32CA4E937B981CD000C65CE90B961/",
       "NumHeight": 7,
       "NumWidth": 10,
@@ -16,7 +16,7 @@
   "GUID": "2f2e0d",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Дейзи Уокер",
+  "Nickname": "Дейзи Уокер (альтернативый оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalkerParallelFront.e8cafc.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DaisyWalkerParallelFront.e8cafc.json
@@ -4,7 +4,7 @@
     "5351": {
       "BackIsHidden": true,
       "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/10373990948271446467/F1A692C8308EAAB113EC1765D000D94E059DEA36/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/18012242273645333186/099745E161EA1BF38D3E3C94554EF6B90A3F6C1C/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/14454306519756578604/E7407DE3F4D3F8E730E32A8B87D68A2B1EA8ED2D/",
       "NumHeight": 7,
       "NumWidth": 10,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "e8cafc",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Дейзи Уокер",
+  "Nickname": "Дейзи Уокер (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DexterDrake.57668a/DexterDrake.3f629d.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DexterDrake.57668a/DexterDrake.3f629d.json
@@ -11,12 +11,11 @@
       "UniqueBack": true
     }
   },
-  "Description": "Promo version",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/DexterDrake.57668a/DexterDrake.3f629d.gmnotes",
   "GUID": "3f629d",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Dexter Drake",
+  "Nickname": "Декстер Дрейк",
   "Tags": [
     "Minicard"
   ],

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DexterDrake.e015f8/DexterDrakepromoversion.3925ce.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/DexterDrake.e015f8/DexterDrakepromoversion.3925ce.json
@@ -1,22 +1,22 @@
 {
-  "CardID": 274137,
+  "CardID": 587410,
   "CustomDeck": {
-    "2741": {
+    "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845464/80687C9319FA2015F3D9F7CBEB4C55FBF045B27D/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845971/A678BD374EC4DE672206B5EF7EB57DC885BC839C/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
       "NumHeight": 7,
       "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }
   },
-  "Description": "The Magician",
+  "Description": "Чародей. Ветеран.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/DexterDrake.e015f8/DexterDrakepromoversion.3925ce.gmnotes",
   "GUID": "3925ce",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Dexter Drake (promo version)",
+  "Nickname": "Декстер Дрейк (промо версия)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/FatherMateoParallel.eb96e7.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/FatherMateoParallel.eb96e7.json
@@ -18,13 +18,13 @@
       "URL": "https://steamusercontent-a.akamaihd.net/ugc/2462982115649258367/C20CC4C299A6FE5F1ECAB968E15BE590337CC019/"
     }
   ],
-  "Description": "Believer. Warden.",
+  "Description": "Верующий. Служитель.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/FatherMateoParallel.eb96e7.gmnotes",
   "GUID": "eb96e7",
   "HideWhenFaceDown": false,
   "LuaScript": "require(\"playercards/cards/FatherMateoParallel\")",
   "Name": "CardCustom",
-  "Nickname": "Отец Матео",
+  "Nickname": "Отец Матео (альтернативный)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/FatherMateoParallelBack.eb96e8.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/FatherMateoParallelBack.eb96e8.json
@@ -11,12 +11,12 @@
       "UniqueBack": true
     }
   },
-  "Description": "Believer. Warden.",
+  "Description": "Верующий. Служитель.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/FatherMateoParallelBack.eb96e8.gmnotes",
   "GUID": "eb96e8",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Отец Матео",
+  "Nickname": "Отец Матео (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/FatherMateoParallelFront.eb96e9.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/FatherMateoParallelFront.eb96e9.json
@@ -18,13 +18,13 @@
       "URL": "https://steamusercontent-a.akamaihd.net/ugc/2462982115649258367/C20CC4C299A6FE5F1ECAB968E15BE590337CC019/"
     }
   ],
-  "Description": "Believer. Warden.",
+  "Description": "Верующий. Служитель.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/FatherMateoParallelFront.eb96e9.gmnotes",
   "GUID": "eb96e9",
   "HideWhenFaceDown": false,
   "LuaScript": "require(\"playercards/cards/FatherMateoParallel\")",
   "Name": "CardCustom",
-  "Nickname": "Отец Матео",
+  "Nickname": "Отец Матео (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/GloriaGoldberg.571596.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/GloriaGoldberg.571596.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "2702": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14846109107864080525/F4EB9FA9AB31ED89E54DB30F4C7864EF6F401094/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16988189147037424546/DD4AAFF5BCB118E3C577B339C07DA112122A5BB1/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17919946578547348108/3C35A0AFF50890E82C0EB3088F7D256F19086998/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13637224579030300002/F318D03813837E0008B705B4E8F1317AABAE438C/",
       "NumHeight": 2,
       "NumWidth": 3,
       "Type": 0,

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnes.48b174/JennyBarnes.703327.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnes.48b174/JennyBarnes.703327.json
@@ -11,12 +11,11 @@
       "UniqueBack": true
     }
   },
-  "Description": "Promo version",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/JennyBarnes.48b174/JennyBarnes.703327.gmnotes",
   "GUID": "703327",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Jenny Barnes",
+  "Nickname": "Дженни Барнс",
   "Tags": [
     "Minicard"
   ],

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnes.9058d3/JennyBarnespromoversion.b954f6.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnes.9058d3/JennyBarnespromoversion.b954f6.json
@@ -1,22 +1,22 @@
 {
-  "CardID": 273631,
+  "CardID": 587400,
   "CustomDeck": {
-    "2736": {
+    "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845464/80687C9319FA2015F3D9F7CBEB4C55FBF045B27D/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845971/A678BD374EC4DE672206B5EF7EB57DC885BC839C/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
       "NumHeight": 7,
       "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }
   },
-  "Description": "The Dilettante",
+  "Description": "Скиталец.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/JennyBarnes.9058d3/JennyBarnespromoversion.b954f6.gmnotes",
   "GUID": "b954f6",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Jenny Barnes (promo version)",
+  "Nickname": "Дженни Барнс (промо версия)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnesParallel.9058d4.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnesParallel.9058d4.json
@@ -16,7 +16,7 @@
   "GUID": "9058d4",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Дженни Барнс",
+  "Nickname": "Дженни Барнс (альтернативная)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnesParallelBack.9058d5.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnesParallelBack.9058d5.json
@@ -16,7 +16,7 @@
   "GUID": "9058d5",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Дженни Барнс",
+  "Nickname": "Дженни Барнс (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnesParallelFront.9058d6.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JennyBarnesParallelFront.9058d6.json
@@ -3,7 +3,7 @@
   "CustomDeck": {
     "152": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/13425524382240719918/9543043C14C4FF59D1E58DF0417F5FB791A0AB04/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/13019545258418025306/5DC7C518453DFF57A02D7A5C9D192AB69F118A33/",
       "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17895231687492342350/AEE9E5F17D89F9FBF6B5CC93A3C98C8F9AD08352/",
       "NumHeight": 1,
       "NumWidth": 1,
@@ -16,7 +16,7 @@
   "GUID": "9058d6",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Дженни Барнс",
+  "Nickname": "Дженни Барнс (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JimCulverParallel.72bf31.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JimCulverParallel.72bf31.json
@@ -16,7 +16,7 @@
   "GUID": "72bf31",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Джим Кальвер",
+  "Nickname": "Джим Кальвер (альтернативный)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JimCulverParallelBack.aba863.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JimCulverParallelBack.aba863.json
@@ -3,10 +3,10 @@
   "CustomDeck": {
     "8468": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17601547900673869898/D56981F037235FCF74DD34D47F5E258EA2C5D4DD/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17372569015394663156/46FED45B4320B6F49B19DF1DFF2F59AADBFD16B8/",
-      "NumHeight": 2,
-      "NumWidth": 4,
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/16056850150476707401/C99EF7C9BA95BC24CC6B437AF24D489CFC5A51F5/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/11149620368148947702/F2C8850FDDF1ECD3F65911DF2D293685498537C7/",
+      "NumHeight": 1,
+      "NumWidth": 1,
       "Type": 0,
       "UniqueBack": true
     }
@@ -16,7 +16,7 @@
   "GUID": "aba863",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Джим Кальвер",
+  "Nickname": "Джим Кальвер (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JimCulverParallelFront.c5fc80.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/JimCulverParallelFront.c5fc80.json
@@ -16,7 +16,7 @@
   "GUID": "c5fc80",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Джим Кальвер",
+  "Nickname": "Джим Кальвер (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/MontereyJackParallel.46b146.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/MontereyJackParallel.46b146.json
@@ -16,7 +16,7 @@
   "GUID": "46b146",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Монтерей Джек",
+  "Nickname": "Монтерей Джек (альтернативный)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/MontereyJackParallelBack.46b148.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/MontereyJackParallelBack.46b148.json
@@ -16,7 +16,7 @@
   "GUID": "46b148",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Монтерей Джек",
+  "Nickname": "Монтерей Джек (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/MontereyJackParallelFront.46b147.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/MontereyJackParallelFront.46b147.json
@@ -3,7 +3,7 @@
   "CustomDeck": {
     "137": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/12684300681115431347/0CEA450D65FB088061F80CFCF27D5EC95F9B41F7/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/10967203410693400084/2AEA6C09F6A7DB9D4D79EAE502D53FFEE2B6EB38/",
       "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17066444302249166477/8BE927679DBC62E825957729EF6D455BB0405610/",
       "NumHeight": 1,
       "NumWidth": 1,
@@ -16,7 +16,7 @@
   "GUID": "46b147",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Монтерей Джек",
+  "Nickname": "Монтерей Джек (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/NormanWithers.a5d9bb/NormanWitherspromoversion.9e2c64.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/NormanWithers.a5d9bb/NormanWitherspromoversion.9e2c64.json
@@ -15,7 +15,7 @@
   "GUID": "9e2c64",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Norman Withers (promo version)",
+  "Nickname": "Норман Уизерс",
   "Tags": [
     "Minicard"
   ],

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/NormanWithers.e0a155/NormanWitherspromoversion.49634c.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/NormanWithers.e0a155/NormanWitherspromoversion.49634c.json
@@ -1,22 +1,22 @@
 {
-  "CardID": 440900,
+  "CardID": 587407,
   "CustomDeck": {
-    "4409": {
+    "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1697277388086987553/817496FCFFBF0B8ADCE3B09A9671D6F549BE5881/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1697277388086987329/F381129808CB4D0ECD8508777784ECD8B7C1691F/",
-      "NumHeight": 2,
-      "NumWidth": 2,
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
+      "NumHeight": 7,
+      "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }
   },
-  "Description": "The Astronomer",
+  "Description": "Мискатоник.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/NormanWithers.e0a155/NormanWitherspromoversion.49634c.gmnotes",
   "GUID": "49634c",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Norman Withers (promo version)",
+  "Nickname": "Норман Уизерс (промо версия)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RexMurphyParallel.0a5492.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RexMurphyParallel.0a5492.json
@@ -16,7 +16,7 @@
   "GUID": "0a5492",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Рекс Мерфи",
+  "Nickname": "Рекс Мерфи (альтернативный)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RexMurphyParallelBack.0a5493.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RexMurphyParallelBack.0a5493.json
@@ -4,7 +4,7 @@
     "141": {
       "BackIsHidden": true,
       "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11688700655052899794/5D15B5F3CF59D65588C075ED69A59B4D05CDAB73/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/11028639619567675000/85FB58207232B5BD9C252E872C4075CA536C7D49/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13187155457041572737/5B1BEC9BF91438CB6948BF718098CC14492696C4/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "0a5493",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Рекс Мерфи",
+  "Nickname": "Рекс Мерфи (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RexMurphyParallelFront.0a5494.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RexMurphyParallelFront.0a5494.json
@@ -3,7 +3,7 @@
   "CustomDeck": {
     "142": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11688700655052899794/5D15B5F3CF59D65588C075ED69A59B4D05CDAB73/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14667487238827804759/C6CC649AA343CA1722F132A6EBF127ABE28FBE71/",
       "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17953135261779128448/791772EFD0F3AA53D3D8B3D8AF14B5281CD49438/",
       "NumHeight": 1,
       "NumWidth": 1,
@@ -16,7 +16,7 @@
   "GUID": "0a5494",
   "HideWhenFaceDown": false,
   "Name": "CardCustom",
-  "Nickname": "Рекс Мерфи",
+  "Nickname": "Рекс Мерфи (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RexMurphyTaboo.0a5491.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RexMurphyTaboo.0a5491.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "143": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11688700655052899794/5D15B5F3CF59D65588C075ED69A59B4D05CDAB73/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/11028639619567675000/85FB58207232B5BD9C252E872C4075CA536C7D49/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14667487238827804759/C6CC649AA343CA1722F132A6EBF127ABE28FBE71/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13187155457041572737/5B1BEC9BF91438CB6948BF718098CC14492696C4/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanks.5bde90/RolandBanks.355b0c.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanks.5bde90/RolandBanks.355b0c.json
@@ -11,12 +11,11 @@
       "UniqueBack": true
     }
   },
-  "Description": "Promo version",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/RolandBanks.5bde90/RolandBanks.355b0c.gmnotes",
   "GUID": "355b0c",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Roland Banks",
+  "Nickname": "Роланд Бэнкс",
   "Tags": [
     "Minicard"
   ],

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanks.5bde90/RolandBanks.cb8701.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanks.5bde90/RolandBanks.cb8701.json
@@ -15,7 +15,7 @@
   "GUID": "cb8701",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Roland Banks",
+  "Nickname": "Роланд Бэнкс",
   "Snap": false,
   "Tags": [
     "Minicard"

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanks.9e9e98/RolandBanks.a684e0.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanks.9e9e98/RolandBanks.a684e0.json
@@ -1,22 +1,22 @@
 {
-  "CardID": 587400,
+  "CardID": 587401,
   "CustomDeck": {
     "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108622/9BA9D571CE81D39DDED8F6F7573E8676964E7723/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108004/768BB33829A836E2AB5E6775A22271BE77585D4A/",
-      "NumHeight": 3,
-      "NumWidth": 3,
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
+      "NumHeight": 7,
+      "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }
   },
-  "Description": "The Fed",
+  "Description": "Агентство. Детектив.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/RolandBanks.9e9e98/RolandBanks.a684e0.gmnotes",
   "GUID": "a684e0",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Roland Banks",
+  "Nickname": "Роланд Бэнкс",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanks.9e9e98/RolandBankspromoversion.e46857.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanks.9e9e98/RolandBankspromoversion.e46857.json
@@ -1,22 +1,22 @@
 {
-  "CardID": 273830,
+  "CardID": 587404,
   "CustomDeck": {
-    "2738": {
+    "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845464/80687C9319FA2015F3D9F7CBEB4C55FBF045B27D/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845971/A678BD374EC4DE672206B5EF7EB57DC885BC839C/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
       "NumHeight": 7,
       "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }
   },
-  "Description": "The Fed",
+  "Description": "Агентство. Детектив.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/RolandBanks.9e9e98/RolandBankspromoversion.e46857.gmnotes",
   "GUID": "e46857",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Roland Banks (promo version)",
+  "Nickname": "Роланд Бэнкс (промо версия)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanksParallel.502768.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanksParallel.502768.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5361": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17476153865357053984/BC2551E024F81BE20AB907036386B260A5FA989C/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13862183931001703890/6D9E24F458B1EFD149696023F53F5BD84178F8D0/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/15400230344327046031/854113B27D7AC932EBBF15FF204C2F05D9F8BA92/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16077969242151131833/0225C496DFC756DC10653817D15401BA0C3D920D/",
       "NumHeight": 3,
       "NumWidth": 3,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "502768",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Роланд Бэнкс",
+  "Nickname": "Роланд Бэнкс (альтернативный)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanksParallelBack.560cef.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanksParallelBack.560cef.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5361": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17476153865357053984/BC2551E024F81BE20AB907036386B260A5FA989C/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13862183931001703890/6D9E24F458B1EFD149696023F53F5BD84178F8D0/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/15400230344327046031/854113B27D7AC932EBBF15FF204C2F05D9F8BA92/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16077969242151131833/0225C496DFC756DC10653817D15401BA0C3D920D/",
       "NumHeight": 3,
       "NumWidth": 3,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "560cef",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Роланд Бэнкс",
+  "Nickname": "Роланд Бэнкс (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanksParallelFront.f7361e.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/RolandBanksParallelFront.f7361e.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5361": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17476153865357053984/BC2551E024F81BE20AB907036386B260A5FA989C/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13862183931001703890/6D9E24F458B1EFD149696023F53F5BD84178F8D0/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/15400230344327046031/854113B27D7AC932EBBF15FF204C2F05D9F8BA92/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16077969242151131833/0225C496DFC756DC10653817D15401BA0C3D920D/",
       "NumHeight": 3,
       "NumWidth": 3,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "f7361e",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Роланд Бэнкс",
+  "Nickname": "Роланд Бэнкс (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SilasMarsh.3f92cf/SilasMarshpromoversion.cd3308.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SilasMarsh.3f92cf/SilasMarshpromoversion.cd3308.json
@@ -1,22 +1,22 @@
 {
-  "CardID": 272429,
+  "CardID": 587409,
   "CustomDeck": {
-    "2724": {
+    "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845464/80687C9319FA2015F3D9F7CBEB4C55FBF045B27D/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1011562618093845971/A678BD374EC4DE672206B5EF7EB57DC885BC839C/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
       "NumHeight": 7,
       "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }
   },
-  "Description": "The Sailor",
+  "Description": "Скиталец.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/SilasMarsh.3f92cf/SilasMarshpromoversion.cd3308.gmnotes",
   "GUID": "cd3308",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Silas Marsh (promo version)",
+  "Nickname": "Сайлас Марш (промо версия)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SilasMarsh.574b59/SilasMarsh.a7b8f6.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SilasMarsh.574b59/SilasMarsh.a7b8f6.json
@@ -11,12 +11,11 @@
       "UniqueBack": true
     }
   },
-  "Description": "Promo version",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/SilasMarsh.574b59/SilasMarsh.a7b8f6.gmnotes",
   "GUID": "a7b8f6",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Silas Marsh",
+  "Nickname": "Сайлас Марш",
   "Tags": [
     "Minicard"
   ],

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOToole.6b00ec/SkidsOToole.02463b.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOToole.6b00ec/SkidsOToole.02463b.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5871": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800341634/C8EF1EDA589007989C51031F8CD42B23956EA7CE/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800340918/16F5E89C36494A9A7D4C191DFF376E340BAABD00/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
       "NumHeight": 2,
       "NumWidth": 3,
       "Type": 0,

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOToole.9015b4/SkidsOToole.a41f81.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOToole.9015b4/SkidsOToole.a41f81.json
@@ -1,12 +1,12 @@
 {
-  "CardID": 587402,
+  "CardID": 587403,
   "CustomDeck": {
     "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108622/9BA9D571CE81D39DDED8F6F7573E8676964E7723/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108004/768BB33829A836E2AB5E6775A22271BE77585D4A/",
-      "NumHeight": 3,
-      "NumWidth": 3,
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
+      "NumHeight": 7,
+      "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOTooleParallel.22ebb2.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOTooleParallel.22ebb2.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "2702": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14846109107864080525/F4EB9FA9AB31ED89E54DB30F4C7864EF6F401094/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16988189147037424546/DD4AAFF5BCB118E3C577B339C07DA112122A5BB1/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17919946578547348108/3C35A0AFF50890E82C0EB3088F7D256F19086998/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13637224579030300002/F318D03813837E0008B705B4E8F1317AABAE438C/",
       "NumHeight": 2,
       "NumWidth": 3,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "22ebb2",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Скат О'Тул",
+  "Nickname": "Скат О'Тул (альтернативный)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOTooleParallelBack.a03077.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOTooleParallelBack.a03077.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "2702": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14846109107864080525/F4EB9FA9AB31ED89E54DB30F4C7864EF6F401094/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16988189147037424546/DD4AAFF5BCB118E3C577B339C07DA112122A5BB1/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17919946578547348108/3C35A0AFF50890E82C0EB3088F7D256F19086998/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13637224579030300002/F318D03813837E0008B705B4E8F1317AABAE438C/",
       "NumHeight": 2,
       "NumWidth": 3,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "a03077",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Скат О'Тул",
+  "Nickname": "Скат О'Тул (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOTooleParallelFront.8116a6.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/SkidsOTooleParallelFront.8116a6.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "2702": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14846109107864080525/F4EB9FA9AB31ED89E54DB30F4C7864EF6F401094/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16988189147037424546/DD4AAFF5BCB118E3C577B339C07DA112122A5BB1/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/17919946578547348108/3C35A0AFF50890E82C0EB3088F7D256F19086998/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13637224579030300002/F318D03813837E0008B705B4E8F1317AABAE438C/",
       "NumHeight": 2,
       "NumWidth": 3,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "8116a6",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Скат О'Тул",
+  "Nickname": "Скат О'Тул (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/WendyAdams.fc1d17/WendyAdams.11bcb3.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/WendyAdams.fc1d17/WendyAdams.11bcb3.json
@@ -1,12 +1,12 @@
 {
-  "CardID": 587404,
+  "CardID": 587406,
   "CustomDeck": {
     "5874": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108622/9BA9D571CE81D39DDED8F6F7573E8676964E7723/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/1856052392800108004/768BB33829A836E2AB5E6775A22271BE77585D4A/",
-      "NumHeight": 3,
-      "NumWidth": 3,
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/11695143700702511351/5EDC4471447D9092F8F9173DDE87ADF1ACA3FCB2/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9710848457000697148/6036AB241B50A0B5C6CA8F7F2498CF7969FB4DF0/",
+      "NumHeight": 7,
+      "NumWidth": 10,
       "Type": 0,
       "UniqueBack": true
     }

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/WendyAdamsParallel.fd91ea.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/WendyAdamsParallel.fd91ea.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5358": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/15040272564966943525/446035E5A8E805A94870EF077C1C1B11F145A200/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17625266458348138809/AF08F8F2F1F9C13173E2E54FE1F07B08BA2B9CCA/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/10753649352767012094/9262BC63972517C3C10F77493070780BDC68B574/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17631638116274416247/463F08D49AE52B09E047A20EA457E9FDCA227A65/",
       "NumHeight": 3,
       "NumWidth": 3,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "fd91ea",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Венди Адамс",
+  "Nickname": "Венди Адамс (альтернативная)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/WendyAdamsParallelBack.4232d9.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/WendyAdamsParallelBack.4232d9.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5358": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/15040272564966943525/446035E5A8E805A94870EF077C1C1B11F145A200/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17625266458348138809/AF08F8F2F1F9C13173E2E54FE1F07B08BA2B9CCA/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/10753649352767012094/9262BC63972517C3C10F77493070780BDC68B574/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17631638116274416247/463F08D49AE52B09E047A20EA457E9FDCA227A65/",
       "NumHeight": 3,
       "NumWidth": 3,
       "Type": 0,
@@ -24,7 +24,7 @@
   "HideWhenFaceDown": false,
   "LuaScript": "require(\"playercards/cards/WendyAdams\")",
   "Name": "Card",
-  "Nickname": "Венди Адамс",
+  "Nickname": "Венди Адамс (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/WendyAdamsParallelFront.61503e.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/WendyAdamsParallelFront.61503e.json
@@ -3,8 +3,8 @@
   "CustomDeck": {
     "5358": {
       "BackIsHidden": true,
-      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/15040272564966943525/446035E5A8E805A94870EF077C1C1B11F145A200/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17625266458348138809/AF08F8F2F1F9C13173E2E54FE1F07B08BA2B9CCA/",
+      "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/10753649352767012094/9262BC63972517C3C10F77493070780BDC68B574/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17631638116274416247/463F08D49AE52B09E047A20EA457E9FDCA227A65/",
       "NumHeight": 3,
       "NumWidth": 3,
       "Type": 0,
@@ -16,7 +16,7 @@
   "GUID": "61503e",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Венди Адамс",
+  "Nickname": "Венди Адамс (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/ZoeySamarasParallel.98a0e2.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/ZoeySamarasParallel.98a0e2.json
@@ -18,13 +18,13 @@
       "URL": "https://steamusercontent-a.akamaihd.net/ugc/2462982115649258367/C20CC4C299A6FE5F1ECAB968E15BE590337CC019/"
     }
   ],
-  "Description": "Believer. Hunter.",
+  "Description": "Верующий. Охотник.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/ZoeySamarasParallel.98a0e2.gmnotes",
   "GUID": "98a0e2",
   "HideWhenFaceDown": false,
   "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
-  "Nickname": "Зои Самарас",
+  "Nickname": "Зои Самарас (альтернативная)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/ZoeySamarasParallelBack.98a0e4.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/ZoeySamarasParallelBack.98a0e4.json
@@ -11,12 +11,12 @@
       "UniqueBack": true
     }
   },
-  "Description": "Believer. Hunter.",
+  "Description": "Верующий. Охотник.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/ZoeySamarasParallelBack.98a0e4.gmnotes",
   "GUID": "98a0e4",
   "HideWhenFaceDown": false,
   "Name": "Card",
-  "Nickname": "Зои Самарас",
+  "Nickname": "Зои Самарас (альтернативный оборот)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",

--- a/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/ZoeySamarasParallelFront.98a0e3.json
+++ b/decomposed/campaign/Language Pack Russian - Player Cards/LanguagePackRussian-PlayerCards.RussianI/ZoeySamarasParallelFront.98a0e3.json
@@ -18,13 +18,13 @@
       "URL": "https://steamusercontent-a.akamaihd.net/ugc/2462982115649258367/C20CC4C299A6FE5F1ECAB968E15BE590337CC019/"
     }
   ],
-  "Description": "Believer. Hunter.",
+  "Description": "Верующий. Охотник.",
   "GMNotes_path": "LanguagePackRussian-PlayerCards.RussianI/ZoeySamarasParallelFront.98a0e3.gmnotes",
   "GUID": "98a0e3",
   "HideWhenFaceDown": false,
   "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
-  "Nickname": "Зои Самарас",
+  "Nickname": "Зои Самарас (альтернативное лицо)",
   "SidewaysCard": true,
   "Tags": [
     "Investigator",


### PR DESCRIPTION
1. Fix Devourer Below broken image box URL
2. Fix half-parallel investigators (they were incorrectly processed in the localization, and were showing up as either full parallels or regular investigators)
3. Add Russian promo/book/revised core investigator images
