### PR TITLE
Change -6 to -7 in FoHV expert bag

### DIFF
--- a/src/DifficultySelectors/10-FHV-Base.ttslua
+++ b/src/DifficultySelectors/10-FHV-Base.ttslua
@@ -2,7 +2,7 @@ tokenData = {
   Easy = { token = { 'p1', 'p1', '0', '0', '0', 'm1', 'm1', 'm1', 'm2', 'm2', 'm3', 'skull', 'skull', 'blue' } },
   Standard = { token = { 'p1', '0', '0', 'm1', 'm1', 'm1', 'm2', 'm2', 'm3', 'm3', 'm4', 'skull', 'skull', 'blue' } },
   Hard = { token = { '0', '0', '0', 'm1', 'm1', 'm2', 'm2', 'm3', 'm3', 'm5', 'm5', 'm7', 'skull', 'skull', 'blue' } },
-  Expert = { token = { '0', 'm1', 'm1', 'm2', 'm2', 'm3', 'm3', 'm4', 'm5', 'm5', 'm6', 'm6', 'm8', 'skull', 'skull', 'blue' } }
+  Expert = { token = { '0', 'm1', 'm1', 'm2', 'm2', 'm3', 'm3', 'm4', 'm5', 'm5', 'm6', 'm7', 'm8', 'skull', 'skull', 'blue' } }
 }
 
 require("DifficultySelectorLibrary")


### PR DESCRIPTION
From the FAQ:
<img width="444" height="64" alt="image" src="https://github.com/user-attachments/assets/1a1c23a0-61d0-40e1-a7ef-f40e13936de7" />
Just because Expert bag was not hard enough (And, well, because there is just one -6 token even in the Revised core)