### PR TITLE
NoV - Hide facedown locations that are supposed to be hidden

### DIFF
--- a/downloadable/campaign/night_of_vespers_campaign_expansion.json
+++ b/downloadable/campaign/night_of_vespers_campaign_expansion.json
@@ -5019,6 +5019,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 299200,
               "CustomDeck": {
                 "1000": {
@@ -5047,6 +5048,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 299000,
               "CustomDeck": {
                 "1001": {
@@ -5075,6 +5077,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 298900,
               "CustomDeck": {
                 "1002": {
@@ -5103,6 +5106,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 299100,
               "CustomDeck": {
                 "1003": {
@@ -12258,6 +12262,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 100700,
               "CustomDeck": {
                 "1007": {
@@ -12287,6 +12292,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 100800,
               "CustomDeck": {
                 "1008": {
@@ -12316,6 +12322,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 101000,
               "CustomDeck": {
                 "1010": {
@@ -12345,6 +12352,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 101100,
               "CustomDeck": {
                 "1011": {
@@ -12374,6 +12382,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 101200,
               "CustomDeck": {
                 "1012": {
@@ -12403,6 +12412,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 101300,
               "CustomDeck": {
                 "1013": {
@@ -12432,6 +12442,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 101400,
               "CustomDeck": {
                 "1014": {
@@ -12461,6 +12472,7 @@
                 "Location",
                 "ScenarioCard"
               ],
+              "HideWhenFaceDown": true,
               "CardID": 315400,
               "CustomDeck": {
                 "1000": {
@@ -20457,7 +20469,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 266400,
           "CustomDeck": {
             "2664": {
@@ -20652,7 +20664,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 101000,
           "CustomDeck": {
             "1010": {
@@ -20682,7 +20694,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 101100,
           "CustomDeck": {
             "1011": {
@@ -20712,7 +20724,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 101300,
           "CustomDeck": {
             "1013": {
@@ -20742,7 +20754,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 280100,
           "CustomDeck": {
             "2801": {
@@ -20772,7 +20784,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 101500,
           "CustomDeck": {
             "1015": {
@@ -21126,6 +21138,7 @@
             "Location",
             "ScenarioCard"
           ],
+          "HideWhenFaceDown": true,
           "CardID": 300200,
           "CustomDeck": {
             "3002": {
@@ -22904,6 +22917,7 @@
             "Location",
             "ScenarioCard"
           ],
+          "HideWhenFaceDown": true,
           "CardID": 300300,
           "CustomDeck": {
             "3003": {
@@ -23139,7 +23153,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 101600,
           "CustomDeck": {
             "1016": {
@@ -23170,7 +23184,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 101700,
           "CustomDeck": {
             "1017": {
@@ -23201,7 +23215,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 101800,
           "CustomDeck": {
             "1018": {
@@ -23232,7 +23246,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 101900,
           "CustomDeck": {
             "1019": {
@@ -23263,7 +23277,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 102100,
           "CustomDeck": {
             "1021": {
@@ -23294,7 +23308,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 102200,
           "CustomDeck": {
             "1022": {
@@ -23325,7 +23339,7 @@
             "Location",
             "ScenarioCard"
           ],
-          "HideWhenFaceDown": false,
+          "HideWhenFaceDown": true,
           "CardID": 102300,
           "CustomDeck": {
             "1023": {
@@ -29243,6 +29257,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329500,
                           "CustomDeck": {
                             "1000": {
@@ -29271,6 +29286,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329000,
                           "CustomDeck": {
                             "1001": {
@@ -29299,6 +29315,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 328900,
                           "CustomDeck": {
                             "1002": {
@@ -29327,6 +29344,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 100300,
                           "CustomDeck": {
                             "1003": {
@@ -29355,6 +29373,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329300,
                           "CustomDeck": {
                             "1004": {
@@ -29384,6 +29403,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329700,
                           "CustomDeck": {
                             "1005": {
@@ -29412,6 +29432,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329900,
                           "CustomDeck": {
                             "1006": {
@@ -29440,6 +29461,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329200,
                           "CustomDeck": {
                             "1007": {
@@ -29468,6 +29490,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329100,
                           "CustomDeck": {
                             "1008": {
@@ -29496,6 +29519,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 330000,
                           "CustomDeck": {
                             "1009": {
@@ -29524,6 +29548,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329400,
                           "CustomDeck": {
                             "1010": {
@@ -29552,6 +29577,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329600,
                           "CustomDeck": {
                             "1011": {
@@ -29580,6 +29606,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 329800,
                           "CustomDeck": {
                             "1012": {
@@ -29608,6 +29635,7 @@
                             "Location",
                             "ScenarioCard"
                           ],
+                          "HideWhenFaceDown": true,
                           "CardID": 101300,
                           "CustomDeck": {
                             "1013": {


### PR DESCRIPTION
There are some locations in Night of Vespers that are supposed to be randomized during the setup (they have identical backs, but different front sides), and right now hovering over them shows their names. This PR should fix them all. 
<details>
<summary>List of affected locations</summary>

- Ah Toy's Pleasure Parlor
- The House of Shields
- Madame Moustache's
- Tenebrarum Lodge
- Benevento
- L'Anse aux Meadows
- The Battle of Clontarf
- The Bridge of Sighs
- The Faraway Tsardom
- The Palace at Mount Kunlun
- Tridevi Marg
- Semnai Theai
- Lecture Theatre
- Dining Hall
- Greenhouse
- Natatorium
- Private Recital Chamber
- Student Dormitory
- Threadbare Apartment
- Dreary Apartment
- Derelict Apartment
- Musty Apartment
- Quiet Apartment
- Decaying Apartment
- Tidy Apartment
- Filthy Apartment
- Peaceful Apartment
- Astral Crossroads
- Collapsing Skyway (×2)
- Crumbling Collonade (×2)
- Vault of Contracts
- Endless Corridors (×3)
- Frostbitten Balcony
- Altar of Fading Sorrow
- Shrine of Mirrors
- Unraveling Courtyard (×2)

</details>