### PR TITLE
NoV - Fix blurry locations & act in scenario 1

### DIFF
--- a/downloadable/campaign/night_of_vespers_campaign_expansion.json
+++ b/downloadable/campaign/night_of_vespers_campaign_expansion.json
@@ -25918,8 +25918,8 @@
           ],
           "CustomDeck": {
             "1000": {
-              "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/14452416189875400704/D64BA9EA9B42D2FFAAB55517F6D423440C01387D/",
-              "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/10369821255366403778/E0D3241797732E938E112E39634AC0EEDA8E65AE/",
+              "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15730712309391448468/E491E04F7FA046890FAF7C5E1C30D253BFE44FB0/",
+              "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/12595135829581445144/3C104FD16FF70A4D9E8721AB08A4594E662DC323/",
               "NumWidth": 1,
               "NumHeight": 1,
               "BackIsHidden": true,
@@ -25927,8 +25927,8 @@
               "Type": 0
             },
             "2986": {
-              "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/12821770577560299550/D55EC40534CA8FB3D3F3FCE0D0D815FD4A9BA0C1/",
-              "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/13351544810418241497/E0D3241797732E938E112E39634AC0EEDA8E65AE/",
+              "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/14640347724379005315/27769A5C8B6C596801CC7382B03B286404AB60EC/",
+              "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/15283312260577231079/3C104FD16FF70A4D9E8721AB08A4594E662DC323/",
               "NumWidth": 1,
               "NumHeight": 1,
               "BackIsHidden": true,
@@ -25956,8 +25956,8 @@
               "CardID": 100000,
               "CustomDeck": {
                 "1000": {
-                  "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/14452416189875400704/D64BA9EA9B42D2FFAAB55517F6D423440C01387D/",
-                  "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/10369821255366403778/E0D3241797732E938E112E39634AC0EEDA8E65AE/",
+                  "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15730712309391448468/E491E04F7FA046890FAF7C5E1C30D253BFE44FB0/",
+                  "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/12595135829581445144/3C104FD16FF70A4D9E8721AB08A4594E662DC323/",
                   "NumWidth": 1,
                   "NumHeight": 1,
                   "BackIsHidden": true,
@@ -25985,8 +25985,8 @@
               "CardID": 298600,
               "CustomDeck": {
                 "2986": {
-                  "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/12821770577560299550/D55EC40534CA8FB3D3F3FCE0D0D815FD4A9BA0C1/",
-                  "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/13351544810418241497/E0D3241797732E938E112E39634AC0EEDA8E65AE/",
+                  "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/14640347724379005315/27769A5C8B6C596801CC7382B03B286404AB60EC/",
+                  "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/15283312260577231079/3C104FD16FF70A4D9E8721AB08A4594E662DC323/",
                   "NumWidth": 1,
                   "NumHeight": 1,
                   "BackIsHidden": true,
@@ -26117,8 +26117,8 @@
           ],
           "CustomDeck": {
             "2988": {
-              "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/10769636292224703761/5FE4C4F6E93E813BD7E6470926D229F7704A15BC/",
-              "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14909654843249305651/EA6C721BC2520A721E54038152669AFBB6651ED6/",
+              "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15161109308091861294/97F2DB3DCFECA2D7EEC60D890B0833765DCE6370/",
+              "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14645934681154487488/E2E4D3FB2BD5469B70A97945AFB0189FAC54D7D1/",
               "NumWidth": 1,
               "NumHeight": 1,
               "BackIsHidden": true,
@@ -26163,8 +26163,8 @@
               "CardID": 298800,
               "CustomDeck": {
                 "2988": {
-                  "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/10769636292224703761/5FE4C4F6E93E813BD7E6470926D229F7704A15BC/",
-                  "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14909654843249305651/EA6C721BC2520A721E54038152669AFBB6651ED6/",
+                  "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15161109308091861294/97F2DB3DCFECA2D7EEC60D890B0833765DCE6370/",
+                  "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/14645934681154487488/E2E4D3FB2BD5469B70A97945AFB0189FAC54D7D1/",
                   "NumWidth": 1,
                   "NumHeight": 1,
                   "BackIsHidden": true,


### PR DESCRIPTION
Some of the cards in scenario 1 of Night of Vespers Campaign are very blurry. This PR probably should not be merged, since fixed images are hosted on my steamcloud, but it shows which cards are affected and has corrected images.
<details>
<summary> Comparison</summary>
<img width="1346" height="1118" alt="image" src="https://github.com/user-attachments/assets/4dc66de9-0cf2-4161-8445-0e1ecd4dac49" />
</details>