### PR TITLE
Remove scripting on player cards in russian i18n

### DIFF
--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкер.25e2db.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкер.25e2db.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Чародей.",
   "GMNotes": "{\n  \"id\": \"01004\"\n}",
   "GUID": "25e2db",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Агнес Бейкер",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкер.25e2db/АгнесБейкер.6797bb.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкер.25e2db/АгнесБейкер.6797bb.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Чародей.",
   "GMNotes": "{\n  \"id\": \"01004\"\n}",
   "GUID": "6797bb",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Агнес Бейкер",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкер.25e2db/АгнесБейкер.a9b6e3.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкер.25e2db/АгнесБейкер.a9b6e3.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Чародей.",
   "GMNotes": "{\n  \"id\": \"01004\"\n}",
   "GUID": "a9b6e3",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Агнес Бейкер",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкер.25e2db/АгнесБейкер.a9b6e4.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкер.25e2db/АгнесБейкер.a9b6e4.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Чародей.",
   "GMNotes": "{\n  \"id\": \"01004\"\n}",
   "GUID": "a9b6e4",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Агнес Бейкер",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкеральтернативныйоборот.909f30.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкеральтернативныйоборот.909f30.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Чародей.",
   "GMNotes": "{\n  \"id\": \"01004-pb\"\n}",
   "GUID": "909f30",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Агнес Бейкер (альтернативный оборот)",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкеральтернативныйоборот.909f30/АгнесБейкеральтернативныйоборот.665117.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/АгнесБейкеральтернативныйоборот.909f30/АгнесБейкеральтернативныйоборот.665117.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Чародей.",
   "GMNotes": "{\n  \"id\": \"01004-pb\"\n}",
   "GUID": "665117",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Агнес Бейкер (альтернативный оборот)",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Анализ.80285f.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Анализ.80285f.json
@@ -11,13 +11,6 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Приобретённый.",
   "GMNotes": "{\n  \"id\": \"09049\"\n}",
   "GUID": "80285f",

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Бастион.tdc028.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Бастион.tdc028.json
@@ -14,7 +14,6 @@
   "Description": "Ритуал.",
   "GMNotes": "{\n  \"id\": \"11028\"\n}",
   "GUID": "tdc028",
-  "LuaScript": "require(\"playercards/cards/Bulwark2\")",
   "Name": "CardCustom",
   "Nickname": "Бастион",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/БлагосклонностьЛуны1.542a70.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/БлагосклонностьЛуны1.542a70.json
@@ -14,7 +14,6 @@
   "Description": "Сделка. Проклятая.",
   "GMNotes": "{\n  \"id\": \"07271\"\n}",
   "GUID": "542a70",
-  "LuaScript": "require(\"playercards/cards/FavoroftheMoon1\")",
   "Name": "Card",
   "Nickname": "Благосклонность Луны (1)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/БлагосклонностьСолнца1.1e6a06.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/БлагосклонностьСолнца1.1e6a06.json
@@ -14,7 +14,6 @@
   "Description": "Сделка. Благословенная.",
   "GMNotes": "{\n  \"id\": \"07272\"\n}",
   "GUID": "1e6a06",
-  "LuaScript": "require(\"playercards/cards/FavoroftheSun1\")",
   "Name": "Card",
   "Nickname": "Благосклонность Солнца (1)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Боглюбиттроицу2.45956a.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Боглюбиттроицу2.45956a.json
@@ -11,13 +11,6 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Дух.",
   "GMNotes": "{\n  \"id\": \"07161\"\n}",
   "GUID": "45956a",

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамс.fc1d17.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамс.fc1d17.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Скиталец.",
   "GMNotes": "{\n  \"id\": \"01005\"\n}",
   "GUID": "fc1d17",
-  "LuaScript": "require(\"playercards/cards/WendyAdams\")",
   "Name": "Card",
   "Nickname": "Венди Адамс",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамс.fc1d17/ВендиАдамс.08bc6c.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамс.fc1d17/ВендиАдамс.08bc6c.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Скиталец.",
   "GMNotes": "{\n  \"id\": \"01005\"\n}",
   "GUID": "08bc6c",
-  "LuaScript": "require(\"playercards/cards/WendyAdams\")",
   "Name": "Card",
   "Nickname": "Венди Адамс",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамс.fc1d17/ВендиАдамс.08bc6d.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамс.fc1d17/ВендиАдамс.08bc6d.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Скиталец.",
   "GMNotes": "{\n  \"id\": \"01005\"\n}",
   "GUID": "08bc6d",
-  "LuaScript": "require(\"playercards/cards/WendyAdams\")",
   "Name": "Card",
   "Nickname": "Венди Адамс",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамс.fc1d17/ВендиАдамс.11bcb3.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамс.fc1d17/ВендиАдамс.11bcb3.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Скиталец.",
   "GMNotes": "{\n  \"id\": \"01005\"\n}",
   "GUID": "11bcb3",
-  "LuaScript": "require(\"playercards/cards/WendyAdams\")",
   "Name": "Card",
   "Nickname": "Венди Адамс",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамсальтернативныйоборот.4232d9.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамсальтернативныйоборот.4232d9.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Скиталец. Благословенная. Проклятая.",
   "GMNotes": "{\n  \"id\": \"01005-pb\"\n}",
   "GUID": "4232d9",
-  "LuaScript": "require(\"playercards/cards/WendyAdams\")",
   "Name": "Card",
   "Nickname": "Венди Адамс (альтернативный оборот)",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамсальтернативныйоборот.4232d9/ВендиАдамсальтернативныйоборот.5de1f4.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ВендиАдамсальтернативныйоборот.4232d9/ВендиАдамсальтернативныйоборот.5de1f4.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Скиталец. Благословенная. Проклятая.",
   "GMNotes": "{\n  \"id\": \"01005-pb\"\n}",
   "GUID": "5de1f4",
-  "LuaScript": "require(\"playercards/cards/WendyAdams\")",
   "Name": "Card",
   "Nickname": "Венди Адамс (альтернативный оборот)",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Вороновоперо.23b96a.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Вороновоперо.23b96a.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09042-c\"\n}",
   "GUID": "23b96a",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/TheRavenQuillUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Вороново перо",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Густыемеха.275450.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Густыемеха.275450.json
@@ -11,17 +11,9 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Вещь. Защита.",
   "GMNotes": "{\n  \"id\": \"08126\"\n}",
   "GUID": "275450",
-  "LuaScript": "require(\"playercards/cards/HeavyFurs\")",
   "Name": "Card",
   "Nickname": "Густые меха",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ДарНоденса.tdc094.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ДарНоденса.tdc094.json
@@ -14,7 +14,6 @@
   "Description": "Ритуал.",
   "GMNotes": "{\n  \"id\": \"11094\"\n}",
   "GUID": "tdc094",
-  "LuaScript": "require(\"playercards/cards/GiftofNodens\")",
   "Name": "CardCustom",
   "Nickname": "Дар Ноденса",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Дезориентация.tdc043.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Дезориентация.tdc043.json
@@ -14,7 +14,6 @@
   "Description": "Ритуал.",
   "GMNotes": "{\n  \"id\": \"11043\"\n}",
   "GUID": "tdc043",
-  "LuaScript": "require(\"playercards/cards/Misdirection2\")",
   "Name": "CardCustom",
   "Nickname": "Дезориентация",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ДжорджБарнаби.tdc017.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ДжорджБарнаби.tdc017.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Юрист",
   "GMNotes": "{\n  \"id\": \"11017\"\n}",
   "GUID": "tdc017",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "CardCustom",
   "Nickname": "Джордж Барнаби",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ДианаСтэнли.32b091.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ДианаСтэнли.32b091.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Культист. Серебряные Сумерки.",
   "GMNotes": "{\n  \"id\": \"05004\"\n}",
   "GUID": "32b091",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Диана Стэнли",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ДианаСтэнли.32b091/ДианаСтэнли.63542e.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ДианаСтэнли.32b091/ДианаСтэнли.63542e.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Культист. Серебряные Сумерки.",
   "GMNotes": "{\n  \"id\": \"05004\"\n}",
   "GUID": "63542e",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Диана Стэнли",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Живыечернила.19a05b.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Живыечернила.19a05b.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09079-c\"\n}",
   "GUID": "19a05b",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/LivingInkUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[]]",
   "Name": "CardCustom",
   "Nickname": "Живые чернила",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Завесамглы.tdc060.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Завесамглы.tdc060.json
@@ -14,7 +14,6 @@
   "Description": "Ритуал.",
   "GMNotes": "{\n  \"id\": \"11060\"\n}",
   "GUID": "tdc060",
-  "LuaScript": "require(\"playercards/cards/Obscure2\")",
   "Name": "CardCustom",
   "Nickname": "Завеса мглы",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Защитнаяформула1.0fd4ae.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Защитнаяформула1.0fd4ae.json
@@ -14,7 +14,6 @@
   "Description": "Ритуал. Благословенный.",
   "GMNotes": "{\n  \"id\": \"04031\"\n}",
   "GUID": "0fd4ae",
-  "LuaScript": "require(\"playercards/cards/ProtectiveIncantation1\")",
   "Name": "Card",
   "Nickname": "Защитная формула (1)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Звздысошлись.600a3c.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Звздысошлись.600a3c.json
@@ -14,7 +14,6 @@
   "Description": "Предсказание.",
   "GMNotes": "{\n  \"id\": \"06028\"\n}",
   "GUID": "600a3c",
-  "LuaScript": "require(\"playercards/cards/TheStarsAreRight\")",
   "Name": "Card",
   "Nickname": "Звёзды сошлись",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Зловещийобразец.tdc039.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Зловещийобразец.tdc039.json
@@ -14,7 +14,6 @@
   "Description": "Существо. Наука.",
   "GMNotes": "{\n  \"id\": \"11039\"\n}",
   "GUID": "tdc039",
-  "LuaScript": "require(\"playercards/cards/UncannySpecimen\")",
   "Name": "CardCustom",
   "Nickname": "Зловещий образец",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗмеиЙига.678391.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗмеиЙига.678391.json
@@ -14,7 +14,6 @@
   "Description": "Гуманоид. Монстр. Змея.",
   "GMNotes": "{\n  \"id\": \"04014\"\n}",
   "GUID": "678391",
-  "LuaScript": "require(\"playercards/cards/SerpentsofYig\")",
   "Name": "Card",
   "Nickname": "Змеи Йига",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗмеиЙига.678392.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗмеиЙига.678392.json
@@ -14,7 +14,6 @@
   "Description": "Humanoid. Monster. Serpent.",
   "GMNotes": "{\n  \"id\": \"90083\"\n}",
   "GUID": "678392",
-  "LuaScript": "require(\"playercards/cards/SerpentsofYigAdvanced\")",
   "Name": "CardCustom",
   "Nickname": "Змеи Йига",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗнакЗелотафа.tdc070.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗнакЗелотафа.tdc070.json
@@ -14,7 +14,6 @@
   "Description": "Защитный символ",
   "GMNotes": "{\n  \"id\": \"11070\"\n}",
   "GUID": "tdc070",
-  "LuaScript": "require(\"playercards/cards/SignofXelotaph\")",
   "Name": "CardCustom",
   "Nickname": "Знак Зелотафа",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗоиСамарасальтернативная.98a0e2.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗоиСамарасальтернативная.98a0e2.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Верующий. Охотник.",
   "GMNotes": "{\n  \"id\": \"02001-p\"\n}",
   "GUID": "98a0e2",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Зои Самарас (альтернативная)",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗоиСамарасальтернативная.98a0e2/ЗоиСамарасальтернативная.cf29c1.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗоиСамарасальтернативная.98a0e2/ЗоиСамарасальтернативная.cf29c1.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Верующий. Охотник.",
   "GMNotes": "{\n  \"id\": \"02001-p\"\n}",
   "GUID": "cf29c1",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Зои Самарас (альтернативная)",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗоиСамарасальтернативноелицо.98a0e3.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗоиСамарасальтернативноелицо.98a0e3.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Верующий. Охотник.",
   "GMNotes": "{\n  \"id\": \"02001-pf\"\n}",
   "GUID": "98a0e3",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Зои Самарас (альтернативное лицо)",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗоиСамарасальтернативноелицо.98a0e3/ЗоиСамарасальтернативноелицо.6ac968.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЗоиСамарасальтернативноелицо.98a0e3/ЗоиСамарасальтернативноелицо.6ac968.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Верующий. Охотник.",
   "GMNotes": "{\n  \"id\": \"02001-pf\"\n}",
   "GUID": "6ac968",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Зои Самарас (альтернативное лицо)",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/КлючСоломона4.ae54c6.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/КлючСоломона4.ae54c6.json
@@ -11,33 +11,14 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    },
-    {
-      "Name": "token-bless",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/9789346007703151704/AF58317B4B90FDBB2859D667717956A24F838F9E/"
-    },
-    {
-      "Name": "token-curse",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15101822659710471244/CA7EF7D227D3BD3001A52D6D1EC40F631752270C/"
-    }
-  ],
   "Description": "Вещь. Книга. Благословенная. Проклятая.",
   "GMNotes": "{\n  \"id\": \"10104\"\n}",
   "GUID": "ae54c6",
-  "LuaScript": "require(\"playercards/cards/KeyofSolomon4\")",
   "Name": "Card",
   "Nickname": "Ключ Соломона (4)",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,
     "scaleZ": 1
-  },
-  "XmlUI": "<Include src=\"playercards/KeyofSolomon4.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Книгаживыхмифов.c5fb1f.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Книгаживыхмифов.c5fb1f.json
@@ -11,33 +11,14 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    },
-    {
-      "Name": "token-bless",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/9789346007703151704/AF58317B4B90FDBB2859D667717956A24F838F9E/"
-    },
-    {
-      "Name": "token-curse",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15101822659710471244/CA7EF7D227D3BD3001A52D6D1EC40F631752270C/"
-    }
-  ],
   "Description": "Вещь. Книга. Благословенная. Проклятая.",
   "GMNotes": "{\n  \"id\": \"10013\"\n}",
   "GUID": "c5fb1f",
-  "LuaScript": "require(\"playercards/cards/BookofLivingMyths\")",
   "Name": "Card",
   "Nickname": "Книга живых мифов",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,
     "scaleZ": 1
-  },
-  "XmlUI": "<Include src=\"playercards/BookofLivingMyths.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/КохакуНаруками.54eaa7.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/КохакуНаруками.54eaa7.json
@@ -12,32 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "token-blue",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17504007405478299050/DC8691C239014FE7DDABB886BB1D383C05DC490F/"
-    },
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    },
-    {
-      "Name": "token-bless",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/9789346007703151704/AF58317B4B90FDBB2859D667717956A24F838F9E/"
-    },
-    {
-      "Name": "token-curse",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15101822659710471244/CA7EF7D227D3BD3001A52D6D1EC40F631752270C/"
-    }
-  ],
   "Description": "Учёный. Благословенный. Проклятый.",
   "GMNotes": "{\n  \"id\": \"10012\"\n}",
   "GUID": "54eaa7",
-  "LuaScript": "require(\"playercards/cards/KohakuNarukami\")",
   "Name": "Card",
   "Nickname": "Кохаку Наруками",
   "SidewaysCard": true,
@@ -48,6 +25,5 @@
     "scaleX": 1.15,
     "scaleY": 1,
     "scaleZ": 1.15
-  },
-  "XmlUI": "<Include src=\"playercards/KohakuNarukami.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/КохакуНаруками.54eaa7/КохакуНаруками.027d6c.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/КохакуНаруками.54eaa7/КохакуНаруками.027d6c.json
@@ -11,32 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "token-blue",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17504007405478299050/DC8691C239014FE7DDABB886BB1D383C05DC490F/"
-    },
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    },
-    {
-      "Name": "token-bless",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/9789346007703151704/AF58317B4B90FDBB2859D667717956A24F838F9E/"
-    },
-    {
-      "Name": "token-curse",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15101822659710471244/CA7EF7D227D3BD3001A52D6D1EC40F631752270C/"
-    }
-  ],
   "Description": "Учёный. Благословенный. Проклятый.",
   "GMNotes": "{\n  \"id\": \"10012\"\n}",
   "GUID": "027d6c",
-  "LuaScript": "require(\"playercards/cards/KohakuNarukami\")",
   "Name": "Card",
   "Nickname": "Кохаку Наруками",
   "SidewaysCard": true,
@@ -44,6 +21,5 @@
     "scaleX": 1.15,
     "scaleY": 1,
     "scaleZ": 1.15
-  },
-  "XmlUI": "<Include src=\"playercards/KohakuNarukami.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Красныечасы2.814c79.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Красныечасы2.814c79.json
@@ -11,23 +11,14 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Вещь. Редкая.",
   "GMNotes": "{\n  \"id\": \"08053\"\n}",
   "GUID": "814c79",
-  "LuaScript": "require(\"playercards/cards/TheRedClock\")",
   "Name": "Card",
   "Nickname": "Красные часы (2)",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,
     "scaleZ": 1
-  },
-  "XmlUI": "<Include src=\"playercards/TheRedClock.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Красныечасы5.696894.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Красныечасы5.696894.json
@@ -11,23 +11,14 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Вещь. Редкая.",
   "GMNotes": "{\n  \"id\": \"08058\"\n}",
   "GUID": "696894",
-  "LuaScript": "require(\"playercards/cards/TheRedClock\")",
   "Name": "Card",
   "Nickname": "Красные часы (5)",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,
     "scaleZ": 1
-  },
-  "XmlUI": "<Include src=\"playercards/TheRedClock.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/КристаллсознакомСтаршихбогов3.949ca2.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/КристаллсознакомСтаршихбогов3.949ca2.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Редкая. Благословенная.",
   "GMNotes": "{\n  \"id\": \"04235\"\n}",
   "GUID": "949ca2",
-  "LuaScript": "require(\"playercards/cards/CrystallineElderSign3\")",
   "Name": "Card",
   "Nickname": "Кристалл со знаком Старших богов (3)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Ложныйзавет2.3442f5.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Ложныйзавет2.3442f5.json
@@ -11,22 +11,9 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    },
-    {
-      "Name": "token-curse",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15101822659710471244/CA7EF7D227D3BD3001A52D6D1EC40F631752270C/"
-    }
-  ],
   "Description": "Завет. Проклятый.",
   "GMNotes": "{\n  \"id\": \"07116\"\n}",
   "GUID": "3442f5",
-  "LuaScript": "require(\"playercards/cards/FalseCovenant\")",
   "Name": "Card",
   "Nickname": "Ложный завет (2)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Лучистыйзалп1.92c295.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Лучистыйзалп1.92c295.json
@@ -14,7 +14,6 @@
   "Description": "Дух. Заклинание. Благословенное.",
   "GMNotes": "{\n  \"id\": \"07153\"\n}",
   "GUID": "92c295",
-  "LuaScript": "require(\"playercards/cards/RadiantSmite1\")",
   "Name": "Card",
   "Nickname": "Лучистый залп (1)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Манускриптвеков.df9809.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Манускриптвеков.df9809.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Редкая. Книга. Благословенная.",
   "GMNotes": "{\n  \"id\": \"04013\"\n}",
   "GUID": "df9809",
-  "LuaScript": "require(\"playercards/cards/TheCodexofAges\")",
   "Name": "Card",
   "Nickname": "Манускрипт веков",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Манускриптвеков.df9810.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Манускриптвеков.df9810.json
@@ -14,7 +14,6 @@
   "Description": "Item. Relic. Tome. Blessed.",
   "GMNotes": "{\n  \"id\": \"90082\"\n}",
   "GUID": "df9810",
-  "LuaScript": "require(\"playercards/cards/TheCodexofAgesAdvanced\")",
   "Name": "CardCustom",
   "Nickname": "Манускрипт веков",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/МаркХэрриган.01ac1b.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/МаркХэрриган.01ac1b.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Ветеран.",
   "GMNotes": "{\n  \"id\": \"03001\"\n}",
   "GUID": "01ac1b",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Марк Хэрриган",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/МаркХэрриган.01ac1b/МаркХэрриган.1c98d5.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/МаркХэрриган.01ac1b/МаркХэрриган.1c98d5.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Ветеран.",
   "GMNotes": "{\n  \"id\": \"03001\"\n}",
   "GUID": "1c98d5",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Марк Хэрриган",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/НатаниэльЧо.65588a.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/НатаниэльЧо.65588a.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Преступник. Служитель.",
   "GMNotes": "{\n  \"id\": \"60101\"\n}",
   "GUID": "65588a",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Натаниэль Чо",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/НатаниэльЧо.65588a/НатаниэльЧо.d02272.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/НатаниэльЧо.65588a/НатаниэльЧо.d02272.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Преступник. Служитель.",
   "GMNotes": "{\n  \"id\": \"60101\"\n}",
   "GUID": "d02272",
-  "LuaScript": "require(\"playercards/CardsWithPhaseButtons\")",
   "Name": "Card",
   "Nickname": "Натаниэль Чо",
   "SidewaysCard": true,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Неотступный1.45386d.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Неотступный1.45386d.json
@@ -14,7 +14,6 @@
   "Description": "Приобретённый.",
   "GMNotes": "{\n  \"id\": \"07196\"\n}",
   "GUID": "45386d",
-  "LuaScript": "require(\"playercards/cards/Unrelenting1\")",
   "Name": "Card",
   "Nickname": "Неотступный (1)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Непромах.ef8f08.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Непромах.ef8f08.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09101-c\"\n}",
   "GUID": "ef8f08",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/GrizzledUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Не промах",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Нефтида4.5659d1.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Нефтида4.5659d1.json
@@ -14,7 +14,6 @@
   "Description": "Союзник. Благословенная.",
   "GMNotes": "{\n  \"id\": \"07262\"\n}",
   "GUID": "5659d1",
-  "LuaScript": "require(\"playercards/cards/Nephthys4\")",
   "Name": "Card",
   "Nickname": "Нефтида (4)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/НкосиМабати3.6c5628.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/НкосиМабати3.6c5628.json
@@ -11,62 +11,9 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "token-skull",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/18025605666872937547/BDAB049A331E3528626DA3B7CBA621F1846E472E/"
-    },
-    {
-      "Name": "token-bless",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/9789346007703151704/AF58317B4B90FDBB2859D667717956A24F838F9E/"
-    },
-    {
-      "Name": "token-curse",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15101822659710471244/CA7EF7D227D3BD3001A52D6D1EC40F631752270C/"
-    },
-    {
-      "Name": "token-cultist",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/14817787635446001123/43990FCC095A8AE2C3398C7D67A6C068DA6A6749/"
-    },
-    {
-      "Name": "token-tablet",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/14738962035650089903/05C897C573865E2513D8B08CD68D5ED5CC7E689C/"
-    },
-    {
-      "Name": "token-elder",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/10616150464475155709/9D3E87A4406D441F8BACEAAE05A4215D57D4A36C/"
-    },
-    {
-      "Name": "token-frost",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17068703597159033722/27E998B2DCB82BF6F2B544FF7C1A831048BE68F8/"
-    },
-    {
-      "Name": "token-red",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17280416909004990974/BC72E714C4DF998F1D0F5ED56AF267EBF949C215/"
-    },
-    {
-      "Name": "token-blue",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17504007405478299050/DC8691C239014FE7DDABB886BB1D383C05DC490F/"
-    },
-    {
-      "Name": "token-custom-token",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/10878293235710132120/E4C2B2B69282A4EE15FE290FF6B08BEFC8FCA65C/"
-    }
-  ],
   "Description": "Союзник. Чародей.",
   "GMNotes": "{\n  \"id\": \"08091\"\n}",
   "GUID": "6c5628",
-  "LuaScript": "require(\"playercards/cards/NkosiMabati3\")",
   "Name": "Card",
   "Nickname": "Нкоси Мабати (3)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Обвинительныепоказания.dc4a62.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Обвинительныепоказания.dc4a62.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09059-c\"\n}",
   "GUID": "dc4a62",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/DamningTestimonyUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Обвинительные показания",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Обрядочищения.974743.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Обрядочищения.974743.json
@@ -14,7 +14,6 @@
   "Description": "Ритуал. Благословенный.",
   "GMNotes": "{\n  \"id\": \"07019\"\n}",
   "GUID": "974743",
-  "LuaScript": "require(\"playercards/cards/RiteofSanctification\")",
   "Name": "Card",
   "Nickname": "Обряд очищения",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОкулусОбскура.tdc009.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОкулусОбскура.tdc009.json
@@ -14,7 +14,6 @@
   "Description": "Эзотерический окуляр",
   "GMNotes": "{\n  \"id\": \"11009\"\n}",
   "GUID": "tdc009",
-  "LuaScript": "require(\"playercards/cards/OculaObscura\")",
   "Name": "CardCustom",
   "Nickname": "Окулус Обскура",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Осколкипустоты3.b10a71.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Осколкипустоты3.b10a71.json
@@ -14,7 +14,6 @@
   "Description": "Заклинание.",
   "GMNotes": "{\n  \"id\": \"04310\"\n}",
   "GUID": "b10a71",
-  "LuaScript": "require(\"playercards/cards/ShardsoftheVoid3\")",
   "Name": "Card",
   "Nickname": "Осколки пустоты (3)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОтецМатеоальтернативноелицо.eb96e9.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОтецМатеоальтернативноелицо.eb96e9.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Верующий. Служитель.",
   "GMNotes": "{\n  \"id\": \"04004-pf\"\n}",
   "GUID": "eb96e9",
-  "LuaScript": "require(\"playercards/cards/FatherMateoParallel\")",
   "Name": "CardCustom",
   "Nickname": "Отец Матео (альтернативное лицо)",
   "SidewaysCard": true,
@@ -33,6 +25,5 @@
     "scaleX": 1.15,
     "scaleY": 1,
     "scaleZ": 1.15
-  },
-  "XmlUI": "<Include src=\"playercards/FatherMateoParallel.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОтецМатеоальтернативноелицо.eb96e9/ОтецМатеоальтернативноелицо.5ec184.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОтецМатеоальтернативноелицо.eb96e9/ОтецМатеоальтернативноелицо.5ec184.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Верующий. Служитель.",
   "GMNotes": "{\n  \"id\": \"04004-pf\"\n}",
   "GUID": "5ec184",
-  "LuaScript": "require(\"playercards/cards/FatherMateoParallel\")",
   "Name": "CardCustom",
   "Nickname": "Отец Матео (альтернативное лицо)",
   "SidewaysCard": true,
@@ -29,6 +21,5 @@
     "scaleX": 1.15,
     "scaleY": 1,
     "scaleZ": 1.15
-  },
-  "XmlUI": "<Include src=\"playercards/FatherMateoParallel.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОтецМатеоальтернативный.eb96e7.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОтецМатеоальтернативный.eb96e7.json
@@ -12,17 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Верующий. Служитель.",
   "GMNotes": "{\n  \"id\": \"04004-p\"\n}",
   "GUID": "eb96e7",
-  "LuaScript": "require(\"playercards/cards/FatherMateoParallel\")",
   "Name": "CardCustom",
   "Nickname": "Отец Матео (альтернативный)",
   "SidewaysCard": true,
@@ -33,6 +25,5 @@
     "scaleX": 1.15,
     "scaleY": 1,
     "scaleZ": 1.15
-  },
-  "XmlUI": "<Include src=\"playercards/FatherMateoParallel.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОтецМатеоальтернативный.eb96e7/ОтецМатеоальтернативный.1b7774.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ОтецМатеоальтернативный.eb96e7/ОтецМатеоальтернативный.1b7774.json
@@ -11,17 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    }
-  ],
   "Description": "Верующий. Служитель.",
   "GMNotes": "{\n  \"id\": \"04004-p\"\n}",
   "GUID": "1b7774",
-  "LuaScript": "require(\"playercards/cards/FatherMateoParallel\")",
   "Name": "CardCustom",
   "Nickname": "Отец Матео (альтернативный)",
   "SidewaysCard": true,
@@ -29,6 +21,5 @@
     "scaleX": 1.15,
     "scaleY": 1,
     "scaleZ": 1.15
-  },
-  "XmlUI": "<Include src=\"playercards/FatherMateoParallel.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Отточенныеинстинкты.ba0e34.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Отточенныеинстинкты.ba0e34.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09061-c\"\n}",
   "GUID": "ba0e34",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/HonedInstinctUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Отточенные инстинкты",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Охотничьяброня.d2d01b.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Охотничьяброня.d2d01b.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09021-c\"\n}",
   "GUID": "d2d01b",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/HuntersArmorUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Охотничья броня",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Парабеллум.tdc050.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Парабеллум.tdc050.json
@@ -14,13 +14,11 @@
   "Description": "Вещь. Оружие. Огнестрельное. Незаконное.",
   "GMNotes": "{\n  \"id\": \"11050\"\n}",
   "GUID": "tdc050",
-  "LuaScript": "require(\"playercards/cards/LugerP08\")",
   "Name": "CardCustom",
   "Nickname": "«Парабеллум»",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,
     "scaleZ": 1
-  },
-  "XmlUI": "<Include src=\"playercards/Luger.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ПечатьСедьмогознака5.9cbac1.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ПечатьСедьмогознака5.9cbac1.json
@@ -14,7 +14,6 @@
   "Description": "Заклинание. Ритуал.",
   "GMNotes": "{\n  \"id\": \"04311\"\n}",
   "GUID": "9cbac1",
-  "LuaScript": "require(\"playercards/cards/SealoftheSeventhSign5\")",
   "Name": "Card",
   "Nickname": "Печать Седьмого знака (5)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Послепрочтениясжечь1Табу.2ced40.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Послепрочтениясжечь1Табу.2ced40.json
@@ -1,12 +1,12 @@
 {
-  "CardID": 333,
+  "CardID": 100,
   "CustomDeck": {
-    "3": {
+    "1": {
       "BackIsHidden": true,
       "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/13122448189625193699/A2D42E7E5C43D045D72CE5CFC907E4F886C8C690/",
       "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15470148873523370077/084E505EEC523AB69646BFF58AEA90507823A213/",
-      "NumHeight": 6,
-      "NumWidth": 10,
+      "NumHeight": 1,
+      "NumWidth": 1,
       "Type": 0,
       "UniqueBack": false
     }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ПризрачныйщитТабу.tdc071t.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ПризрачныйщитТабу.tdc071t.json
@@ -4,7 +4,7 @@
     "1": {
       "BackIsHidden": true,
       "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/2342503777940352139/A2D42E7E5C43D045D72CE5CFC907E4F886C8C690/",
-      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17272704509934901722/BC25E7255125400F61C8DD9447EB0D5DF3F8864B/",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13949010953315922371/382AED39C408D88F6BF16CEA6EF928FFEA0477B6/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Приспешник.5397a6.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Приспешник.5397a6.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09080-c\"\n}",
   "GUID": "5397a6",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/SummonedServitorUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Приспешник",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Рунныйтопор.4d729b.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Рунныйтопор.4d729b.json
@@ -14,8 +14,6 @@
   "Description": "Вещь. Оружие. Рукопашное.",
   "GMNotes": "{\n  \"id\": \"09022-t-c\"\n}",
   "GUID": "4d729b",
-  "LuaScript": "require(\"localization/ru/playercards/customizable/RunicAxeUpgradeSheetTaboo\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "Card",
   "Nickname": "Рунный топор",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Рунныйтопор.be427d.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Рунныйтопор.be427d.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09022-c\"\n}",
   "GUID": "be427d",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/RunicAxeUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Рунный топор",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Самодельнаяловушка.64dfce.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Самодельнаяловушка.64dfce.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09100-c\"\n}",
   "GUID": "64dfce",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/MakeshiftTrapUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Самодельная ловушка",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн.230835.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн.230835.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Книга.",
   "GMNotes": "{\n  \"id\": \"05116\"\n}",
   "GUID": "230835",
-  "LuaScript": "require(\"playercards/cards/ScrollofSecrets\")",
   "Name": "Card",
   "Nickname": "Свиток тайн",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн3.0b12ac.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн3.0b12ac.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Книга.",
   "GMNotes": "{\n  \"id\": \"05188\"\n}",
   "GUID": "0b12ac",
-  "LuaScript": "require(\"playercards/cards/ScrollofSecrets\")",
   "Name": "Card",
   "Nickname": "Свиток тайн (3)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн3.194d88.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн3.194d88.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Книга.",
   "GMNotes": "{\n  \"id\": \"05189\"\n}",
   "GUID": "194d88",
-  "LuaScript": "require(\"playercards/cards/ScrollofSecrets\")",
   "Name": "Card",
   "Nickname": "Свиток тайн (3)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн3Табу.84a7df.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн3Табу.84a7df.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Книга.",
   "GMNotes": "{\n  \"id\": \"05188-t\"\n}",
   "GUID": "84a7df",
-  "LuaScript": "require(\"playercards/cards/ScrollofSecrets\")",
   "Name": "Card",
   "Nickname": "Свиток тайн (3) (Табу)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн3Табу.c127f1.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Свитоктайн3Табу.c127f1.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Книга.",
   "GMNotes": "{\n  \"id\": \"05189-t\"\n}",
   "GUID": "c127f1",
-  "LuaScript": "require(\"playercards/cards/ScrollofSecrets\")",
   "Name": "Card",
   "Nickname": "Свиток тайн (3) (Табу)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/СвитоктайнТабу.b383b8.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/СвитоктайнТабу.b383b8.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Книга.",
   "GMNotes": "{\n  \"id\": \"05116-t\"\n}",
   "GUID": "b383b8",
-  "LuaScript": "require(\"playercards/cards/ScrollofSecrets\")",
   "Name": "Card",
   "Nickname": "Свиток тайн (Табу)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Своилюди.66b7d5.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Своилюди.66b7d5.json
@@ -11,17 +11,9 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Состояние.",
   "GMNotes": "{\n  \"id\": \"05028\"\n}",
   "GUID": "66b7d5",
-  "LuaScript": "require(\"playercards/cards/WellConnected\")",
   "Name": "Card",
   "Nickname": "Свои люди",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Своилюди3.170127.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Своилюди3.170127.json
@@ -11,17 +11,9 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Состояние.",
   "GMNotes": "{\n  \"id\": \"54006\"\n}",
   "GUID": "170127",
-  "LuaScript": "require(\"playercards/cards/WellConnected\")",
   "Name": "Card",
   "Nickname": "Свои люди (3)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Священноекопь5.28289a.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Священноекопь5.28289a.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Оружие. Рукопашное. Благословенное.",
   "GMNotes": "{\n  \"id\": \"07302\"\n}",
   "GUID": "28289a",
-  "LuaScript": "require(\"playercards/cards/HolySpear5\")",
   "Name": "Card",
   "Nickname": "Священное копьё (5)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Семейноенаследство.394603.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Семейноенаследство.394603.json
@@ -11,23 +11,14 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Дар.",
   "GMNotes": "{\n  \"id\": \"05011\"\n}",
   "GUID": "394603",
-  "LuaScript": "require(\"playercards/cards/FamilyInheritance\")",
   "Name": "Card",
   "Nickname": "Семейное наследство",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,
     "scaleZ": 1
-  },
-  "XmlUI": "<Include src=\"playercards/FamilyInheritance.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Скудныесредства.e5f541.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Скудныесредства.e5f541.json
@@ -14,7 +14,6 @@
   "Description": "Талант.",
   "GMNotes": "{\n  \"id\": \"08071\"\n}",
   "GUID": "e5f541",
-  "LuaScript": "require(\"playercards/cards/ShortSupply\")",
   "Name": "Card",
   "Nickname": "Скудные средства",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Словосилы.0d9481.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Словосилы.0d9481.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09081-c\"\n}",
   "GUID": "0d9481",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/PowerWordUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Слово силы",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Словосилы.ebce85.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Словосилы.ebce85.json
@@ -14,8 +14,6 @@
   "Description": "Заклинание.",
   "GMNotes": "{\n  \"id\": \"09081-t-c\"\n}",
   "GUID": "ebce85",
-  "LuaScript": "require(\"localization/ru/playercards/customizable/PowerWordUpgradeSheetTaboo\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "Card",
   "Nickname": "Слово силы",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Специальнаямодификация.d2252d.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Специальнаямодификация.d2252d.json
@@ -11,17 +11,9 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Улучшение. Запас.",
   "GMNotes": "{\n  \"id\": \"09023\"\n}",
   "GUID": "d2252d",
-  "LuaScript": "require(\"playercards/cards/CustomModifications\")",
   "Name": "Card",
   "Nickname": "Специальная модификация",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/СтеллаКларк.00e18e.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/СтеллаКларк.00e18e.json
@@ -12,22 +12,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    },
-    {
-      "Name": "token-blue",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17504007405478299050/DC8691C239014FE7DDABB886BB1D383C05DC490F/"
-    }
-  ],
   "Description": "Избранник. Клерк.",
   "GMNotes": "{\n  \"id\": \"60501\"\n}",
   "GUID": "00e18e",
-  "LuaScript": "require(\"playercards/cards/StellaClark\")",
   "Name": "Card",
   "Nickname": "Стелла Кларк",
   "SidewaysCard": true,
@@ -38,6 +25,5 @@
     "scaleX": 1.15,
     "scaleY": 1,
     "scaleZ": 1.15
-  },
-  "XmlUI": "<Include src=\"playercards/StellaClark.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/СтеллаКларк.00e18e/СтеллаКларк.8719e0.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/СтеллаКларк.00e18e/СтеллаКларк.8719e0.json
@@ -11,22 +11,9 @@
       "UniqueBack": true
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_arkhamicons",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/15027120756910078445/49B31DA9BD35FC54A6B33926EA220FBBB2CAD038/"
-    },
-    {
-      "Name": "token-blue",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17504007405478299050/DC8691C239014FE7DDABB886BB1D383C05DC490F/"
-    }
-  ],
   "Description": "Избранник. Клерк.",
   "GMNotes": "{\n  \"id\": \"60501\"\n}",
   "GUID": "8719e0",
-  "LuaScript": "require(\"playercards/cards/StellaClark\")",
   "Name": "Card",
   "Nickname": "Стелла Кларк",
   "SidewaysCard": true,
@@ -34,6 +21,5 @@
     "scaleX": 1.15,
     "scaleY": 1,
     "scaleZ": 1.15
-  },
-  "XmlUI": "<Include src=\"playercards/StellaClark.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Судныйдень.e701af.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Судныйдень.e701af.json
@@ -14,7 +14,6 @@
   "Description": "Конец времён.",
   "GMNotes": "{\n  \"id\": \"07040\"\n}",
   "GUID": "e701af",
-  "LuaScript": "require(\"playercards/cards/DayofReckoning\")",
   "Name": "Card",
   "Nickname": "Судный день",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Счастливаямонетка2.aae31c.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Счастливаямонетка2.aae31c.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Оберег. Проклятый.",
   "GMNotes": "{\n  \"id\": \"07224\"\n}",
   "GUID": "aae31c",
-  "LuaScript": "require(\"playercards/cards/LuckyPenny\")",
   "Name": "Card",
   "Nickname": "«Счастливая» монетка (2)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.05e697.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.05e697.json
@@ -14,7 +14,6 @@
   "Description": "Безумие.",
   "GMNotes": "{\n  \"id\": \"08728\"\n}",
   "GUID": "05e697",
-  "LuaScript": "require(\"playercards/cards/Tekeli-li\")",
   "Name": "Card",
   "Nickname": "Текели-ли",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.0ba293.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.0ba293.json
@@ -14,7 +14,6 @@
   "Description": "Безумие.",
   "GMNotes": "{\n  \"id\": \"08725\"\n}",
   "GUID": "0ba293",
-  "LuaScript": "require(\"playercards/cards/Tekeli-li\")",
   "Name": "Card",
   "Nickname": "Текели-ли",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.0ef2ba.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.0ef2ba.json
@@ -14,7 +14,6 @@
   "Description": "Безумие.",
   "GMNotes": "{\n  \"id\": \"08729\"\n}",
   "GUID": "0ef2ba",
-  "LuaScript": "require(\"playercards/cards/Tekeli-li\")",
   "Name": "Card",
   "Nickname": "Текели-ли",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.361f15.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.361f15.json
@@ -14,7 +14,6 @@
   "Description": "Безумие.",
   "GMNotes": "{\n  \"id\": \"08727\"\n}",
   "GUID": "361f15",
-  "LuaScript": "require(\"playercards/cards/Tekeli-li\")",
   "Name": "Card",
   "Nickname": "Текели-ли",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.519e41.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.519e41.json
@@ -14,7 +14,6 @@
   "Description": "Безумие.",
   "GMNotes": "{\n  \"id\": \"08723\"\n}",
   "GUID": "519e41",
-  "LuaScript": "require(\"playercards/cards/Tekeli-li\")",
   "Name": "Card",
   "Nickname": "Текели-ли",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.76409f.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.76409f.json
@@ -14,7 +14,6 @@
   "Description": "Безумие.",
   "GMNotes": "{\n  \"id\": \"08724\"\n}",
   "GUID": "76409f",
-  "LuaScript": "require(\"playercards/cards/Tekeli-li\")",
   "Name": "Card",
   "Nickname": "Текели-ли",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.f5bd65.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Текели-ли.f5bd65.json
@@ -14,7 +14,6 @@
   "Description": "Безумие.",
   "GMNotes": "{\n  \"id\": \"08726\"\n}",
   "GUID": "f5bd65",
-  "LuaScript": "require(\"playercards/cards/Tekeli-li\")",
   "Name": "Card",
   "Nickname": "Текели-ли",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Тмныйритуал.272e6c.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Тмныйритуал.272e6c.json
@@ -14,7 +14,6 @@
   "Description": "Ритуал. Проклятый.",
   "GMNotes": "{\n  \"id\": \"07026\"\n}",
   "GUID": "272e6c",
-  "LuaScript": "require(\"playercards/cards/DarkRitual\")",
   "Name": "Card",
   "Nickname": "Тёмный ритуал",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Укрепляющаясонсыворотка.98c5af.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Укрепляющаясонсыворотка.98c5af.json
@@ -11,17 +11,9 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Вещь. Наука.",
   "GMNotes": "{\n  \"id\": \"06159\"\n}",
   "GUID": "98c5af",
-  "LuaScript": "require(\"playercards/cards/DreamEnhancingSerum\")",
   "Name": "Card",
   "Nickname": "Укрепляющая сон сыворотка",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ФлейтаВнешнихбогов4.3cc1e2.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ФлейтаВнешнихбогов4.3cc1e2.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Музыкальная. Редкая. Проклятая.",
   "GMNotes": "{\n  \"id\": \"07268\"\n}",
   "GUID": "3cc1e2",
-  "LuaScript": "require(\"playercards/cards/FluteoftheOuterGods4\")",
   "Name": "Card",
   "Nickname": "Флейта Внешних богов (4)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ФлейтаВнешнихбогов4Табу.453fd1.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ФлейтаВнешнихбогов4Табу.453fd1.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Музыкальная. Редкая. Проклятая.",
   "GMNotes": "{\n  \"id\": \"07268-t\"\n}",
   "GUID": "453fd1",
-  "LuaScript": "require(\"playercards/cards/FluteoftheOuterGods4\")",
   "Name": "Card",
   "Nickname": "Флейта Внешних богов (4) (Табу)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Хорошаяпогода.tdc091.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Хорошаяпогода.tdc091.json
@@ -14,7 +14,6 @@
   "Description": "Благословенное. Удача.",
   "GMNotes": "{\n  \"id\": \"11091\"\n}",
   "GUID": "tdc091",
-  "LuaScript": "require(\"playercards/SkillSelectionCard\")",
   "Name": "CardCustom",
   "Nickname": "Хорошая погода",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Хтоническиймонолит.fc4ce8.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Хтоническиймонолит.fc4ce8.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Редкая. Проклятая.",
   "GMNotes": "{\n  \"id\": \"04030\"\n}",
   "GUID": "fc4ce8",
-  "LuaScript": "require(\"playercards/cards/TheChthonianStone\")",
   "Name": "Card",
   "Nickname": "Хтонический монолит",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Хтоническиймонолит3.a775ad.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Хтоническиймонолит3.a775ad.json
@@ -14,7 +14,6 @@
   "Description": "Вещь. Редкая. Проклятая.",
   "GMNotes": "{\n  \"id\": \"53008\"\n}",
   "GUID": "a775ad",
-  "LuaScript": "require(\"playercards/cards/TheChthonianStone\")",
   "Name": "Card",
   "Nickname": "Хтонический монолит (3)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЦиферблатДревних.tdc046.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЦиферблатДревних.tdc046.json
@@ -14,7 +14,6 @@
   "Description": "Знаки катаклизма",
   "GMNotes": "{\n  \"id\": \"11046\"\n}",
   "GUID": "tdc046",
-  "LuaScript": "require(\"playercards/cards/DialofAncients4Cataclysm\")",
   "Name": "CardCustom",
   "Nickname": "Циферблат Древних",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЦиферблатДревних.tdc047.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЦиферблатДревних.tdc047.json
@@ -14,7 +14,6 @@
   "Description": "Знаки искажения",
   "GMNotes": "{\n  \"id\": \"11047\"\n}",
   "GUID": "tdc047",
-  "LuaScript": "require(\"playercards/cards/DialofAncients4Aberration\")",
   "Name": "CardCustom",
   "Nickname": "Циферблат Древних",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Швейцарскийнож.d706e7.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Швейцарскийнож.d706e7.json
@@ -15,8 +15,6 @@
   "GMNotes": "{\n  \"id\": \"09099-c\"\n}",
   "GUID": "d706e7",
   "Hands": false,
-  "LuaScript": "require(\"localization/ru/playercards/customizable/PocketMultiToolUpgradeSheet\")",
-  "LuaScriptState": "[[0,0,0,0,0,0,0,0,0,0],[\"\",\"\",\"\",\"\",\"\"]]",
   "Name": "CardCustom",
   "Nickname": "Швейцарский нож",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ШубаКлейпула.c1f999.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ШубаКлейпула.c1f999.json
@@ -11,22 +11,9 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    },
-    {
-      "Name": "token-frost",
-      "Type": 0,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17068703597159033722/27E998B2DCB82BF6F2B544FF7C1A831048BE68F8/"
-    }
-  ],
   "Description": "Вещь. Одежда.",
   "GMNotes": "{\n  \"id\": \"08730\"\n}",
   "GUID": "c1f999",
-  "LuaScript": "require(\"playercards/cards/ClaypoolsFurs\")",
   "Name": "Card",
   "Nickname": "Шуба Клейпула",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Щитверы2.06abe0.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Щитверы2.06abe0.json
@@ -14,7 +14,6 @@
   "Description": "Заклинание. Благословенное.",
   "GMNotes": "{\n  \"id\": \"07221\"\n}",
   "GUID": "06abe0",
-  "LuaScript": "require(\"playercards/cards/ShieldofFaith2\")",
   "Name": "Card",
   "Nickname": "Щит веры (2)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЭллиРубаш2.43c3e0.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЭллиРубаш2.43c3e0.json
@@ -14,13 +14,11 @@
   "Description": "Союзник. Ведьма.",
   "GMNotes": "{\n  \"id\": \"09092\"\n}",
   "GUID": "43c3e0",
-  "LuaScript": "require(\"playercards/cards/ElleRubash2\")",
   "Name": "Card",
   "Nickname": "Элли Рубаш (2)",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,
     "scaleZ": 1
-  },
-  "XmlUI": "<Include src=\"playercards/ElleRubash2.xml\"/>"
+  }
 }

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Эмпирическаягипотеза.62c67d.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Эмпирическаягипотеза.62c67d.json
@@ -14,7 +14,6 @@
   "Description": "Талант. Наука.",
   "GMNotes": "{\n  \"id\": \"09041\"\n}",
   "GUID": "62c67d",
-  "LuaScript": "require(\"playercards/cards/EmpiricalHypothesis\")",
   "Name": "Card",
   "Nickname": "Эмпирическая гипотеза",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЭмпирическаягипотезаТабу.62c67e.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/ЭмпирическаягипотезаТабу.62c67e.json
@@ -14,7 +14,6 @@
   "Description": "Талант. Наука.",
   "GMNotes": "{\n  \"id\": \"09041-t\"\n}",
   "GUID": "62c67e",
-  "LuaScript": "require(\"playercards/cards/EmpiricalHypothesis\")",
   "Name": "CardCustom",
   "Nickname": "Эмпирическая гипотеза (Табу)",
   "Transform": {

--- a/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Язаставлю1.294d6.json
+++ b/decomposed/language-pack/Russian - Player Cards/Russian-PlayerCards.RussianI/Язаставлю1.294d6.json
@@ -11,13 +11,6 @@
       "UniqueBack": false
     }
   },
-  "CustomUIAssets": [
-    {
-      "Name": "font_teutonic-arkham",
-      "Type": 1,
-      "URL": "https://steamusercontent-a.akamaihd.net/ugc/17294509164577022713/89328E273B4C5180BF491516CE998DE3C604E162/"
-    }
-  ],
   "Description": "Врождённый.",
   "GMNotes": "{\n  \"id\": \"10031\"\n}",
   "GUID": "294d6",


### PR DESCRIPTION
During the re-upload I accidentally added back the scripting to the cards, that should not supposed to be there. This PR removes it.

Also fixed invalid wording on Russian Spectral Shield taboo card