### PR TITLE
Improve location names and descriptions in Polish language pack

### DIFF
--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.001431.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.001431.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Stary dom",
   "GMNotes": "{\n  \"id\": \"01152\"\n}",
   "GUID": "001431",
   "Name": "CardCustom",

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.499372.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.499372.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Splątany gąszcz",
   "GMNotes": "{\n  \"id\": \"01154\"\n}",
   "GUID": "499372",
   "Name": "CardCustom",

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.5d0d69.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.5d0d69.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Spokojna polana",
   "GMNotes": "{\n  \"id\": \"01155\"\n}",
   "GUID": "5d0d69",
   "Name": "CardCustom",

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.739d6e.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.739d6e.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Urwisko",
   "GMNotes": "{\n  \"id\": \"01153\"\n}",
   "GUID": "739d6e",
   "Name": "CardCustom",

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.a4e1d1.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.a4e1d1.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Zawiłe ścieżki",
   "GMNotes": "{\n  \"id\": \"01151\"\n}",
   "GUID": "a4e1d1",
   "Name": "CardCustom",

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.b94050.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.b94050.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Wyklęta ziemia",
   "GMNotes": "{\n  \"id\": \"01150\"\n}",
   "GUID": "b94050",
   "Name": "CardCustom",

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Alejkanatyłach.b94e71.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Alejkanatyłach.b94e71.json
@@ -15,7 +15,7 @@
   "GUID": "b94e71",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Alejka na tyłach",
+  "Nickname": "Drzwi w korytarzu",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Galeriasztuki.aad58a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Galeriasztuki.aad58a.json
@@ -15,7 +15,7 @@
   "GUID": "aad58a",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Galeria sztuki",
+  "Nickname": "Drzwi w korytarzu",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Rozdartyszlak.556402.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Rozdartyszlak.556402.json
@@ -15,7 +15,7 @@
   "GUID": "556402",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Rozdarty szlak",
+  "Nickname": "Zmieniona ścieżka",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Rzeźniczylas.8b33e9.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Rzeźniczylas.8b33e9.json
@@ -15,7 +15,7 @@
   "GUID": "8b33e9",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Rzeźniczy las",
+  "Nickname": "Rozwidlona ścieżka",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.127e83.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.127e83.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Zastrzeżona część muzeum",
   "GMNotes": "{\n  \"id\": \"02137\"\n}",
   "GUID": "127e83",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.24472c.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.24472c.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Wystawa Meduzy",
   "GMNotes": "{\n  \"id\": \"02133\"\n}",
   "GUID": "24472c",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.483077.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.483077.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Sala umarłych",
   "GMNotes": "{\n  \"id\": \"02136\"\n}",
   "GUID": "483077",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.5e14c3.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.5e14c3.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Wystawa atapaskańska",
   "GMNotes": "{\n  \"id\": \"02132\"\n}",
   "GUID": "5e14c3",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.7060e4.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.7060e4.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Wystawa przyrody naturalnej",
   "GMNotes": "{\n  \"id\": \"02134\"\n}",
   "GUID": "7060e4",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.b88756.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.b88756.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Wystawa egipska",
   "GMNotes": "{\n  \"id\": \"02135\"\n}",
   "GUID": "b88756",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salonka.153760.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salonka.153760.json
@@ -15,7 +15,7 @@
   "GUID": "153760",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Salonka",
+  "Nickname": "Wagon",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Strasznapolana.0f4ffc.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Strasznapolana.0f4ffc.json
@@ -15,7 +15,7 @@
   "GUID": "0f4ffc",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Straszna polana",
+  "Nickname": "Rozwidlona ścieżka",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/StrefadlaVIP-ów.413dc2.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/StrefadlaVIP-ów.413dc2.json
@@ -15,7 +15,7 @@
   "GUID": "413dc2",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Strefa dla VIP-ów",
+  "Nickname": "Drzwi w korytarzu",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Szczelinamiędzywymiarowa.3f1bd5.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Szczelinamiędzywymiarowa.3f1bd5.json
@@ -15,7 +15,7 @@
   "GUID": "3f1bd5",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Szczelina międzywymiarowa",
+  "Nickname": "Zmieniona ścieżka",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.1163da.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.1163da.json
@@ -15,7 +15,7 @@
   "GUID": "1163da",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wagon pasażerski",
+  "Nickname": "Wagon",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.222a38.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.222a38.json
@@ -15,7 +15,7 @@
   "GUID": "222a38",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wagon pasażerski",
+  "Nickname": "Wagon",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.54124e.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.54124e.json
@@ -15,7 +15,7 @@
   "GUID": "54124e",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wagon pasażerski",
+  "Nickname": "Wagon",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.63c94d.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.63c94d.json
@@ -15,7 +15,7 @@
   "GUID": "63c94d",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wagon pasażerski",
+  "Nickname": "Wagon",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.e3d3dd.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.e3d3dd.json
@@ -15,7 +15,7 @@
   "GUID": "e3d3dd",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wagon pasażerski",
+  "Nickname": "Wagon",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonrestauracyjny.a97233.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonrestauracyjny.a97233.json
@@ -15,7 +15,7 @@
   "GUID": "a97233",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wagon restauracyjny",
+  "Nickname": "Wagon",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonsypialny.bdd340.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonsypialny.bdd340.json
@@ -15,7 +15,7 @@
   "GUID": "bdd340",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wagon sypialny",
+  "Nickname": "Wagon",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wyrwanedrzewa.dd592a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wyrwanedrzewa.dd592a.json
@@ -15,7 +15,7 @@
   "GUID": "dd592a",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wyrwane drzewa",
+  "Nickname": "Zmieniona ścieżka",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zagubionewspomnienia.5fb483.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zagubionewspomnienia.5fb483.json
@@ -15,7 +15,7 @@
   "GUID": "5fb483",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Zagubione wspomnienia",
+  "Nickname": "Zmieniona ścieżka",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zamarznięteźródło.203c7a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zamarznięteźródło.203c7a.json
@@ -15,7 +15,7 @@
   "GUID": "203c7a",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Zamarznięte źródło",
+  "Nickname": "Rozwidlona ścieżka",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zniszczonyszlak.e8b238.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zniszczonyszlak.e8b238.json
@@ -15,7 +15,7 @@
   "GUID": "e8b238",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Zniszczony szlak",
+  "Nickname": "Rozwidlona ścieżka",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Pokójprzesłuchań.20e77c.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Pokójprzesłuchań.20e77c.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Pomieszczenie dla przybyszów",
   "GMNotes": "{\n  \"id\": \"04245\"\n}",
   "GUID": "20e77c",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Pokójprzesłuchań.c7e635.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Pokójprzesłuchań.c7e635.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Pomieszczenie pełne posoki",
   "GMNotes": "{\n  \"id\": \"04247\"\n}",
   "GUID": "c7e635",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Pokójprzesłuchań.e02490.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Pokójprzesłuchań.e02490.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Pomieszczenie dla więźniów",
   "GMNotes": "{\n  \"id\": \"04246\"\n}",
   "GUID": "e02490",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Budkaoświetleniowca.deaa03.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Budkaoświetleniowca.deaa03.json
@@ -15,7 +15,7 @@
   "GUID": "deaa03",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Budka oświetleniowca",
+  "Nickname": "Drzwi w przedsionku",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Garderoba.07dd88.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Garderoba.07dd88.json
@@ -15,7 +15,7 @@
   "GUID": "07dd88",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Garderoba",
+  "Nickname": "Drzwi za kulisy",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/GrobowiecCieni.6832ee.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/GrobowiecCieni.6832ee.json
@@ -15,7 +15,7 @@
   "GUID": "6832ee",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Grobowiec Cieni",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Jaskiniapełnakości.7acbc7.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Jaskiniapełnakości.7acbc7.json
@@ -15,7 +15,7 @@
   "GUID": "7acbc7",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Jaskinia pełna kości",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/KaplicaśwAdalberta.2da91b.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/KaplicaśwAdalberta.2da91b.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Niedostępne wody",
   "GMNotes": "{\n  \"id\": \"03297\"\n}",
   "GUID": "2da91b",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/KaplicaśwAdalberta.9a94cb.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/KaplicaśwAdalberta.9a94cb.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Szlak stoi otworem",
   "GMNotes": "{\n  \"id\": \"03296\"\n}",
   "GUID": "9a94cb",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Kasybiletowe.f96d4a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Kasybiletowe.f96d4a.json
@@ -15,7 +15,7 @@
   "GUID": "f96d4a",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Kasy biletowe",
+  "Nickname": "Drzwi w przedsionku",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Kryptazezniczem.a5d6d7.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Kryptazezniczem.a5d6d7.json
@@ -15,7 +15,7 @@
   "GUID": "a5d6d7",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Krypta ze zniczem",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Labiryntkości.dc4987.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Labiryntkości.dc4987.json
@@ -15,7 +15,7 @@
   "GUID": "dc4987",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Labirynt kości",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Podscenie.dc74fa.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Podscenie.dc74fa.json
@@ -15,7 +15,7 @@
   "GUID": "dc74fa",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Podscenie",
+  "Nickname": "Drzwi za kulisy",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Pokójdlaaktorów.e52d3d.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Pokójdlaaktorów.e52d3d.json
@@ -15,7 +15,7 @@
   "GUID": "e52d3d",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Pokój dla aktorów",
+  "Nickname": "Drzwi w przedsionku",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Salaprób.6a9793.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Salaprób.6a9793.json
@@ -15,7 +15,7 @@
   "GUID": "6a9793",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Sala prób",
+  "Nickname": "Drzwi za kulisy",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Separatka.1c0876.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Separatka.1c0876.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Zajęta cela",
   "GMNotes": "{\n  \"id\": \"03179\"\n}",
   "GUID": "1c0876",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Separatka.2c15f1.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Separatka.2c15f1.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Ponura cela",
   "GMNotes": "{\n  \"id\": \"03180\"\n}",
   "GUID": "2c15f1",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Separatka.66c108.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Separatka.66c108.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Izolatka Daniela",
   "GMNotes": "{\n  \"id\": \"03178\"\n}",
   "GUID": "66c108",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Separatka.dec520.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Separatka.dec520.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Znajoma cela",
   "GMNotes": "{\n  \"id\": \"03181\"\n}",
   "GUID": "dec520",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Sklepioneprzejście.e67c1a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Sklepioneprzejście.e67c1a.json
@@ -15,7 +15,7 @@
   "GUID": "e67c1a",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Sklepione przejście",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.09363a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.09363a.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Muzeum historyczne",
   "GMNotes": "{\n  \"id\": \"03130\"\n}",
   "GUID": "09363a",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.0bb5ea.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.0bb5ea.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Archiwum",
   "GMNotes": "{\n  \"id\": \"03129\"\n}",
   "GUID": "0bb5ea",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.15a1a8.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.15a1a8.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Czytelnia",
   "GMNotes": "{\n  \"id\": \"03134\"\n}",
   "GUID": "15a1a8",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.230e6b.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.230e6b.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Sala konferencyjna",
   "GMNotes": "{\n  \"id\": \"03128\"\n}",
   "GUID": "230e6b",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.25260c.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.25260c.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Gabinet Peabody'ego",
   "GMNotes": "{\n  \"id\": \"03137\"\n}",
   "GUID": "25260c",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.564e49.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.564e49.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Archiwum",
   "GMNotes": "{\n  \"id\": \"03138\"\n}",
   "GUID": "564e49",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.95d584.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.95d584.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Księgozbiór historyczny",
   "GMNotes": "{\n  \"id\": \"03133\"\n}",
   "GUID": "95d584",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.b6ce2d.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.b6ce2d.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Muzeum historyczne",
   "GMNotes": "{\n  \"id\": \"03132\"\n}",
   "GUID": "b6ce2d",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.b898ff.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/StowarzyszenieHistoryczne.b898ff.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Księgozbiór historyczny",
   "GMNotes": "{\n  \"id\": \"03136\"\n}",
   "GUID": "b898ff",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Studniadusz.ad7132.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Studniadusz.ad7132.json
@@ -15,7 +15,7 @@
   "GUID": "ad7132",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Studnia dusz",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Tunelewblaskuświec.63a64d.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Tunelewblaskuświec.63a64d.json
@@ -15,7 +15,7 @@
   "GUID": "63a64d",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Tunele w blasku świec",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Wieżaopactwa.0031c8.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Wieżaopactwa.0031c8.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Niedostępne wieżyce",
   "GMNotes": "{\n  \"id\": \"03299\"\n}",
   "GUID": "0031c8",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Wieżaopactwa.bb5058.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Wieżaopactwa.bb5058.json
@@ -11,7 +11,6 @@
       "UniqueBack": true
     }
   },
-  "Description": "Szlak stoi otworem",
   "GMNotes": "{\n  \"id\": \"03298\"\n}",
   "GUID": "bb5058",
   "HideWhenFaceDown": true,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Wzburzonykanał.b64713.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Wzburzonykanał.b64713.json
@@ -15,7 +15,7 @@
   "GUID": "b64713",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wzburzony kanał",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Wąskiszyb.8bec89.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Wąskiszyb.8bec89.json
@@ -15,7 +15,7 @@
   "GUID": "8bec89",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Wąski szyb",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Zawaloneprzejście.442f5c.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/ThePathtoCarcosa.244a8e/Zawaloneprzejście.442f5c.json
@@ -15,7 +15,7 @@
   "GUID": "442f5c",
   "HideWhenFaceDown": true,
   "Name": "CardCustom",
-  "Nickname": "Zawalone przejście",
+  "Nickname": "Katakumby",
   "Transform": {
     "scaleX": 1,
     "scaleY": 1,


### PR DESCRIPTION
This commit include changes to locations that can be identified by the name or description showing on the label in the MOD. I either changed the name of the cards to the one appearing on the unrevealed side or remove the description tag. 