### PR TITLE
Update front side of the Closed Doors in Polish language pack

### DIFF
--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Zamkniętedrzwi.5871ff.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Zamkniętedrzwi.5871ff.json
@@ -4,7 +4,7 @@
     "5574": {
       "BackIsHidden": true,
       "BackURL": "https://steamusercontent-a.akamaihd.net/ugc/2342503777940351785/F64D8EFB75A9E15446D24343DA0A6EEF5B3E43DB/",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170595/AH_LCG_Core_Campaign/01174_front.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781592268/01174_front_new_ui4oui.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,


### PR DESCRIPTION
Front side of the Closed Doors encounter card from NotZ in Polish language pack had wrong icon for the test (brain instead of the fist). I have change the URL to point to the scan of the card instead of the JPG created in Arkham Card Maker. Change was tested locally