### PR TITLE
Original DWL back change

### DIFF
--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/BiskupiPotok.06b68b.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/BiskupiPotok.06b68b.json
@@ -4,7 +4,7 @@
     "8100": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961058/Dunwich_Campaign/02202_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961060/Dunwich_Campaign/02202_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17491282031430589590/F8290BDF5CCDB2E8E698AE2E2F1635E2E4572B49/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/BiskupiPotok.53f120.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/BiskupiPotok.53f120.json
@@ -4,7 +4,7 @@
     "4889": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961061/Dunwich_Campaign/02203_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961063/Dunwich_Campaign/02203_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17491282031430589590/F8290BDF5CCDB2E8E698AE2E2F1635E2E4572B49/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Dompośródtrzcin.020402.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Dompośródtrzcin.020402.json
@@ -4,7 +4,7 @@
     "6632": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961144/Dunwich_Campaign/02211_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961145/Dunwich_Campaign/02211_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16092028257090876947/E31F647595FA4EE1ABD29B502D346AC6ECE3CAD5/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Dompośródtrzcin.dc4950.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Dompośródtrzcin.dc4950.json
@@ -4,7 +4,7 @@
     "9945": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961141/Dunwich_Campaign/02210_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961142/Dunwich_Campaign/02210_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/16092028257090876947/E31F647595FA4EE1ABD29B502D346AC6ECE3CAD5/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Kościółkongregacyjny.21d7e6.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Kościółkongregacyjny.21d7e6.json
@@ -4,7 +4,7 @@
     "9769": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961137/Dunwich_Campaign/02209_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961139/Dunwich_Campaign/02209_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/12777937125707902844/76E2E68D57908D7280E855D8DA7B022B07E23278/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Kościółkongregacyjny.56fd96.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Kościółkongregacyjny.56fd96.json
@@ -4,7 +4,7 @@
     "2315": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961133/Dunwich_Campaign/02208_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961135/Dunwich_Campaign/02208_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/12777937125707902844/76E2E68D57908D7280E855D8DA7B022B07E23278/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Lokomotywa.054489.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Lokomotywa.054489.json
@@ -4,7 +4,7 @@
     "6835": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961007/Dunwich_Campaign/02177_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961009/Dunwich_Campaign/02177_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9518787072644791838/6C2868AF68966D2208F29C0F9967FDC6128D495E/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Lokomotywa.225319.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Lokomotywa.225319.json
@@ -4,7 +4,7 @@
     "5669": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960960/Dunwich_Campaign/02175_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960962/Dunwich_Campaign/02175_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9518787072644791838/6C2868AF68966D2208F29C0F9967FDC6128D495E/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Lokomotywa.f9a160.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Lokomotywa.f9a160.json
@@ -4,7 +4,7 @@
     "5270": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961004/Dunwich_Campaign/02176_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961005/Dunwich_Campaign/02176_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/9518787072644791838/6C2868AF68966D2208F29C0F9967FDC6128D495E/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Rozdartyszlak.556402.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Rozdartyszlak.556402.json
@@ -4,7 +4,7 @@
     "3199": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961431/Dunwich_Campaign/02290_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961432/Dunwich_Campaign/02290_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13776715955796719756/2AFD04C27DDB6CA81F02145055EBD0151F36C543/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Rzeźniczylas.8b33e9.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Rzeźniczylas.8b33e9.json
@@ -4,7 +4,7 @@
     "9191": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961385/Dunwich_Campaign/02285_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961386/Dunwich_Campaign/02285_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13947854313934154264/3BC7E90FC1B79DB454B54B8797E6BF1B2F717E08/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.127e83.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.127e83.json
@@ -4,7 +4,7 @@
     "1448": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959222/Dunwich_Campaign/02137_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959224/Dunwich_Campaign/02137_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15531019974813904760/97DD56E6C1E14C96559050162CB914F001C5B1A0/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.24472c.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.24472c.json
@@ -4,7 +4,7 @@
     "4438": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959206/Dunwich_Campaign/02133_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959208/Dunwich_Campaign/02133_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15531019974813904760/97DD56E6C1E14C96559050162CB914F001C5B1A0/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.483077.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.483077.json
@@ -4,7 +4,7 @@
     "7487": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959219/Dunwich_Campaign/02136_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959220/Dunwich_Campaign/02136_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15531019974813904760/97DD56E6C1E14C96559050162CB914F001C5B1A0/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.5e14c3.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.5e14c3.json
@@ -4,7 +4,7 @@
     "1881": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960787/Dunwich_Campaign/02132_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960790/Dunwich_Campaign/02132_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15531019974813904760/97DD56E6C1E14C96559050162CB914F001C5B1A0/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.7060e4.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.7060e4.json
@@ -4,7 +4,7 @@
     "8115": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959211/Dunwich_Campaign/02134_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959213/Dunwich_Campaign/02134_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15531019974813904760/97DD56E6C1E14C96559050162CB914F001C5B1A0/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.b88756.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salawystawowa.b88756.json
@@ -4,7 +4,7 @@
     "6611": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959215/Dunwich_Campaign/02135_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771959217/Dunwich_Campaign/02135_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/15531019974813904760/97DD56E6C1E14C96559050162CB914F001C5B1A0/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salonka.153760.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Salonka.153760.json
@@ -4,7 +4,7 @@
     "4983": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960957/Dunwich_Campaign/02174_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960959/Dunwich_Campaign/02174_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17218315214192173525/3B9A3EAE0B2A37765C6BAFFAD65A81F50C526EBC/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/SalonwCloverClub.16a9d0.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/SalonwCloverClub.16a9d0.json
@@ -4,7 +4,7 @@
     "4820": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771958880/Dunwich_Campaign/02071_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771958881/Dunwich_Campaign/02071_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13166270747930883150/966E38D76E67F6EAF50123B85BB2ECDF4C39D458/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/SklepOsborna.a03914.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/SklepOsborna.a03914.json
@@ -4,7 +4,7 @@
     "6100": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961130/Dunwich_Campaign/02207_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961131/Dunwich_Campaign/02207_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17688308656613545136/02F583EFABAB97261542B4B765C1F6297B26A512/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/SklepOsborna.f3a35a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/SklepOsborna.f3a35a.json
@@ -4,7 +4,7 @@
     "2094": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961072/Dunwich_Campaign/02206_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961073/Dunwich_Campaign/02206_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17688308656613545136/02F583EFABAB97261542B4B765C1F6297B26A512/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Spaloneruiny.8d9c12.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Spaloneruiny.8d9c12.json
@@ -4,7 +4,7 @@
     "7613": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961069/Dunwich_Campaign/02205_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961070/Dunwich_Campaign/02205_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13421299748330016138/6BD499E71D0289A6B0C79A19EBDFCCF7F597F7B6/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Spaloneruiny.8fb2ca.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Spaloneruiny.8fb2ca.json
@@ -4,7 +4,7 @@
     "5920": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961065/Dunwich_Campaign/02204_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961067/Dunwich_Campaign/02204_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13421299748330016138/6BD499E71D0289A6B0C79A19EBDFCCF7F597F7B6/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Strasznapolana.0f4ffc.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Strasznapolana.0f4ffc.json
@@ -4,7 +4,7 @@
     "7799": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961388/Dunwich_Campaign/02286_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961389/Dunwich_Campaign/02286_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13947854313934154264/3BC7E90FC1B79DB454B54B8797E6BF1B2F717E08/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Szczelinamiędzywymiarowa.3f1bd5.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Szczelinamiędzywymiarowa.3f1bd5.json
@@ -4,7 +4,7 @@
     "3127": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961427/Dunwich_Campaign/02289_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961429/Dunwich_Campaign/02289_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13776715955796719756/2AFD04C27DDB6CA81F02145055EBD0151F36C543/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Szkoła.0aa67f.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Szkoła.0aa67f.json
@@ -4,7 +4,7 @@
     "9758": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961147/Dunwich_Campaign/02212_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961148/Dunwich_Campaign/02212_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/10368227484906554395/4FAD29091FE0E4D7270992D23DB1F9A518268DCF",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Szkoła.bc7856.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Szkoła.bc7856.json
@@ -4,7 +4,7 @@
     "9665": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961150/Dunwich_Campaign/02213_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961151/Dunwich_Campaign/02213_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/10368227484906554395/4FAD29091FE0E4D7270992D23DB1F9A518268DCF",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.1163da.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.1163da.json
@@ -4,7 +4,7 @@
     "2849": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960937/Dunwich_Campaign/02168_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960939/Dunwich_Campaign/02168_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17218315214192173525/3B9A3EAE0B2A37765C6BAFFAD65A81F50C526EBC/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.222a38.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.222a38.json
@@ -4,7 +4,7 @@
     "9411": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960944/Dunwich_Campaign/02170_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960946/Dunwich_Campaign/02170_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17218315214192173525/3B9A3EAE0B2A37765C6BAFFAD65A81F50C526EBC/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.54124e.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.54124e.json
@@ -4,7 +4,7 @@
     "6120": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960947/Dunwich_Campaign/02171_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960949/Dunwich_Campaign/02171_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17218315214192173525/3B9A3EAE0B2A37765C6BAFFAD65A81F50C526EBC/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.63c94d.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.63c94d.json
@@ -4,7 +4,7 @@
     "2381": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960934/Dunwich_Campaign/02167_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960935/Dunwich_Campaign/02167_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17218315214192173525/3B9A3EAE0B2A37765C6BAFFAD65A81F50C526EBC/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.e3d3dd.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonpasażerski.e3d3dd.json
@@ -4,7 +4,7 @@
     "9586": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960941/Dunwich_Campaign/02169_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960942/Dunwich_Campaign/02169_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17218315214192173525/3B9A3EAE0B2A37765C6BAFFAD65A81F50C526EBC/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonrestauracyjny.a97233.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonrestauracyjny.a97233.json
@@ -4,7 +4,7 @@
     "3234": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960954/Dunwich_Campaign/02173_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960955/Dunwich_Campaign/02173_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17218315214192173525/3B9A3EAE0B2A37765C6BAFFAD65A81F50C526EBC/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonsypialny.bdd340.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wagonsypialny.bdd340.json
@@ -4,7 +4,7 @@
     "5747": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960951/Dunwich_Campaign/02172_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771960952/Dunwich_Campaign/02172_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/17218315214192173525/3B9A3EAE0B2A37765C6BAFFAD65A81F50C526EBC/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wyrwanedrzewa.dd592a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Wyrwanedrzewa.dd592a.json
@@ -4,7 +4,7 @@
     "7199": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961434/Dunwich_Campaign/02291_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961436/Dunwich_Campaign/02291_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13776715955796719756/2AFD04C27DDB6CA81F02145055EBD0151F36C543/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zagubionewspomnienia.5fb483.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zagubionewspomnienia.5fb483.json
@@ -4,7 +4,7 @@
     "3634": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961437/Dunwich_Campaign/02292_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961439/Dunwich_Campaign/02292_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13776715955796719756/2AFD04C27DDB6CA81F02145055EBD0151F36C543/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zamarznięteźródło.203c7a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zamarznięteźródło.203c7a.json
@@ -4,7 +4,7 @@
     "9280": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961394/Dunwich_Campaign/02288_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961396/Dunwich_Campaign/02288_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13947854313934154264/3BC7E90FC1B79DB454B54B8797E6BF1B2F717E08/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zniszczonyszlak.e8b238.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheDunwichLegacy.401f9f/Zniszczonyszlak.e8b238.json
@@ -4,7 +4,7 @@
     "9812": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961391/Dunwich_Campaign/02287_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771961392/Dunwich_Campaign/02287_back.jpg",
+      "FaceURL": "https://steamusercontent-a.akamaihd.net/ugc/13947854313934154264/3BC7E90FC1B79DB454B54B8797E6BF1B2F717E08/",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,


### PR DESCRIPTION
When I was preparing scans from the Return to the Dunwich Legacy, I noticed that since the cards in the original DWL Polish translation pack are not scans and rather were created in Arkham Cards Maker, it is easy to cheat during the game and distinguish what card's what. This PR includes changes to some backsides of cards from the original language pack.