### PR TITLE
Original NotZ back change

### DIFF
--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Easttown.29926a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Easttown.29926a.json
@@ -4,7 +4,7 @@
     "3524": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170474/AH_LCG_Core_Campaign/01132_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170475/AH_LCG_Core_Campaign/01132_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812757/50027-back_xjodeh.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.001431.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.001431.json
@@ -4,7 +4,7 @@
     "5670": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170543/AH_LCG_Core_Campaign/01152_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170544/AH_LCG_Core_Campaign/01152_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812761/50033-back_psqhnj.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.499372.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.499372.json
@@ -4,7 +4,7 @@
     "1285": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170550/AH_LCG_Core_Campaign/01154_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170551/AH_LCG_Core_Campaign/01154_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812761/50033-back_psqhnj.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.5d0d69.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.5d0d69.json
@@ -4,7 +4,7 @@
     "4415": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170553/AH_LCG_Core_Campaign/01155_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170554/AH_LCG_Core_Campaign/01155_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812761/50033-back_psqhnj.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.739d6e.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.739d6e.json
@@ -4,7 +4,7 @@
     "4340": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170546/AH_LCG_Core_Campaign/01153_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170548/AH_LCG_Core_Campaign/01153_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812761/50033-back_psqhnj.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.a4e1d1.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.a4e1d1.json
@@ -4,7 +4,7 @@
     "8997": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170540/AH_LCG_Core_Campaign/01151_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170541/AH_LCG_Core_Campaign/01151_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812761/50033-back_psqhnj.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.ab58ef.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.ab58ef.json
@@ -4,7 +4,7 @@
     "7695": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170504/AH_LCG_Core_Campaign/01143_back.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170502/AH_LCG_Core_Campaign/01143_front.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812761/50033-back_psqhnj.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.b94050.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/LasyArkham.b94050.json
@@ -4,7 +4,7 @@
     "5398": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170536/AH_LCG_Core_Campaign/01150_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170538/AH_LCG_Core_Campaign/01150_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812761/50033-back_psqhnj.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Northside.fcaf7a.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Northside.fcaf7a.json
@@ -4,7 +4,7 @@
     "4408": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170480/AH_LCG_Core_Campaign/01134_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170482/AH_LCG_Core_Campaign/01134_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812757/50028-back_jotfk6.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Piwnica.520e3d.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Piwnica.520e3d.json
@@ -4,7 +4,7 @@
     "6608": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170416/AH_LCG_Core_Campaign/01114_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170418/AH_LCG_Core_Campaign/01114_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812738/50020-back_cnt77v.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Rivertown.ac09e2.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Rivertown.ac09e2.json
@@ -4,7 +4,7 @@
     "7956": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170451/AH_LCG_Core_Campaign/01125_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170452/AH_LCG_Core_Campaign/01125_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812757/50030-back_x5cxi4.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Strych.956359.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/Strych.956359.json
@@ -4,7 +4,7 @@
     "3229": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170412/AH_LCG_Core_Campaign/01113_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170413/AH_LCG_Core_Campaign/01113_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812740/50018-back_quq6r7.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/UniwersytetMiskatonic.039141.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/NightoftheZealot.5b3bc8/UniwersytetMiskatonic.039141.json
@@ -4,7 +4,7 @@
     "2269": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170464/AH_LCG_Core_Campaign/01129_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1771170466/AH_LCG_Core_Campaign/01129_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1781812756/50029-back_x3uuyc.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,


### PR DESCRIPTION
Similar action to what I did for the DWL and Return to DWL. I changed the orignal backs of some of the cards from the base campaign that I created in Arkham Cards Maker to the scans of the same cards from RtNotZ, so that they are no idistinguishable in game. 