### PR TITLE
The Forgotten Age back fix

### DIFF
--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Coyoacán.45d0ab.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Coyoacán.45d0ab.json
@@ -4,7 +4,7 @@
     "3808": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347308/TFA_Campaign_Cards/04173_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347309/TFA_Campaign_Cards/04173_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1782664415/53044-back_n4vh0w.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/KatedraMetropolitalna.2d9376.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/KatedraMetropolitalna.2d9376.json
@@ -4,7 +4,7 @@
     "3854": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347295/TFA_Campaign_Cards/04169_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347296/TFA_Campaign_Cards/04169_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1782664415/53040-back_opprer.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/ParkChapultepec.0bd57b.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/ParkChapultepec.0bd57b.json
@@ -4,7 +4,7 @@
     "5249": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347298/TFA_Campaign_Cards/04170_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347299/TFA_Campaign_Cards/04170_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1782664416/53041-back_hv6gab.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Ruinyświątyni.10a072.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Ruinyświątyni.10a072.json
@@ -4,7 +4,7 @@
     "4057": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347291/TFA_Campaign_Cards/04168_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347293/TFA_Campaign_Cards/04168_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1782664415/53039-back_by2xmh.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Xochimilco.99eb0b.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Xochimilco.99eb0b.json
@@ -4,7 +4,7 @@
     "3979": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347305/TFA_Campaign_Cards/04172_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347306/TFA_Campaign_Cards/04172_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1782664415/53043-back_hu7nf0.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,

--- a/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Zócalo.aebcef.json
+++ b/decomposed/language-pack/Polish - Campaigns/Polish-Campaigns.PolishC/TheForgottenAge.385a5e/Zócalo.aebcef.json
@@ -4,7 +4,7 @@
     "5104": {
       "BackIsHidden": true,
       "BackURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347301/TFA_Campaign_Cards/04171_front.jpg",
-      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1772347302/TFA_Campaign_Cards/04171_back.jpg",
+      "FaceURL": "https://res.cloudinary.com/dnyyxgsfq/image/upload/v1782664415/53042-back_rmuduc.webp",
       "NumHeight": 1,
       "NumWidth": 1,
       "Type": 0,


### PR DESCRIPTION
This includes that changes to 6 cards from the 4th scenario to align the backside to the scan of the cards from the Return to pack.