### PR TITLE
Fix Chosen of Zbu ID in helper

### DIFF
--- a/src/ChildrenOfBlood/3-BloodMoneyHelper.ttslua
+++ b/src/ChildrenOfBlood/3-BloodMoneyHelper.ttslua
@@ -176,7 +176,7 @@ function setup(_, playerColor)
       ["13091"] = true, -- Child of Blood
       ["13103"] = true, -- Child of Blood
       ["13092"] = true, -- Sanguine Rebirth
-      ["13093"] = true, -- Chosen of Zburamoarte
+      ["13093a"] = true, -- Chosen of Zburamoarte
       ["13097"] = true, -- Spawn of Zburamoarte
       ["13112"] = true, -- Sanguine Cultist
       ["13113"] = true, -- Blood-Crazed Zealot


### PR DESCRIPTION
I'm worried this is all my fault, but the card was spawning in the encounter deck instead of the set-aside chest