### PR TITLE
Added spanish scenario boxes (cob, core2026, tdc)

### DIFF
--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/13VástagosdelaSangre.es_campaignBox_13.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/13VástagosdelaSangre.es_campaignBox_13.json
@@ -125,7 +125,9 @@
     "BackAlley.es_13023",
     "BackAlley.es_13022",
     "13119.es_13119",
-    "13076a.es_13076a"
+    "13076a.es_13076a",
+    "1-RiverofBlood.esriver",
+    "3-BloodMoney.esmoney"
   ],
   "ContainedObjects_path": "13VástagosdelaSangre.es_campaignBox_13",
   "CustomMesh": {

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/13VástagosdelaSangre.es_campaignBox_13/1-RiverofBlood.esriver.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/13VástagosdelaSangre.es_campaignBox_13/1-RiverofBlood.esriver.json
@@ -1,0 +1,35 @@
+{
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/16275908616334566464/0408BD055BC1821AAA4E92D3FEC076B8206E943F/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1301\"\n}",
+  "GUID": "esriver",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "1 - Río de Sangre",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.86,
+    "scaleY": 0.68,
+    "scaleZ": 2.86
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/13VástagosdelaSangre.es_campaignBox_13/3-BloodMoney.esmoney.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/13VástagosdelaSangre.es_campaignBox_13/3-BloodMoney.esmoney.json
@@ -1,0 +1,35 @@
+{
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/14614458391649575469/96AD943608C35D1087DDE8C2427142C82AC4EEF2/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1303\"\n}",
+  "GUID": "esmoney",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "3 - Dinero de Sangre",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.86,
+    "scaleY": 0.68,
+    "scaleZ": 2.86
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/Core2026.856544.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/Core2026.856544.json
@@ -97,17 +97,39 @@
     "Auguriosdellama.fbcec3",
     "Arkhamviva.5add8a",
     "Aguacero.15903a",
-    "AbigailForeman.d94b99"
+    "AbigailForeman.d94b99",
+    "1SpreadingFlames.esspread",
+    "2SmokeandMirrors.essmoke",
+    "3QueenofAsh.esqueen"
   ],
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/9991907252717042800/DB5B53C2DE14800FC6834CA8C93962406DA6ACEC/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515295/AFB8F257CE1E4973F4C06160A2E156C147AEE1E3/",
+    "TypeIndex": 6
+  },
+  "Description": "de Fantasy Flight Games",
+  "GMNotes": "{\n  \"id\": \"CB12\"\n}",
   "ContainedObjects_path": "Core2026.856544",
   "GUID": "856544",
   "Hands": false,
   "HideWhenFaceDown": false,
-  "Name": "Bag",
-  "Nickname": "Core 2026",
+  "Name": "Custom_Model_Bag",
+  "Nickname": "Core 2026 / Hermanos de las Cenizas",
   "Transform": {
+    "rotY": 270,
     "scaleX": 1,
-    "scaleY": 1,
+    "scaleY": 0.14,
     "scaleZ": 1
   }
 }

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/Core2026.856544/1SpreadingFlames.esspread.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/Core2026.856544/1SpreadingFlames.esspread.json
@@ -1,0 +1,52 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "OwnerSteamID": 0,
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/10496458773399511729/C751097C7B4BD8A9E407BC1413031439834C0C2F/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1201\"\n}",
+  "GUID": "esspread",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "1 - Las Llamas Se Propagan",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/Core2026.856544/2SmokeandMirrors.essmoke.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/Core2026.856544/2SmokeandMirrors.essmoke.json
@@ -1,0 +1,52 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "OwnerSteamID": 0,
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/12298708131675367016/F89EDA458386B5C8C6921DA6BE3EC9D4A675F570/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1202\"\n}",
+  "GUID": "essmoke",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "2 - Humo y Espejos",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/Core2026.856544/3QueenofAsh.esqueen.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/Core2026.856544/3QueenofAsh.esqueen.json
@@ -1,0 +1,52 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "OwnerSteamID": 0,
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/17555646091608145511/3FF4AA19E347AB96B0FAD0B38F25995E1629846C/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1203\"\n}",
+  "GUID": "esqueen",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "3 - Reina de las Cenizas",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0.json
@@ -304,17 +304,49 @@
     "Acrópolissumergida.097272",
     "Acrofobia.b22de7",
     "Acantiladosdeobsidiana.963491",
-    "Abismoagitado.b3ab14"
+    "Abismoagitado.b3ab14",
+    "CourtoftheAncients.esb0236f",
+    "ObsidianCanyons.es5b6dd9",
+    "OneLastJob.es58c966",
+    "SepulchreoftheSleeper.esd832ca",
+    "TheApiary.es0d2acb",
+    "TheDoomofArkhamPartI.es4ffb65",
+    "TheDoomofArkhamPartII.esf4cd9e",
+    "TheDrownedQuarter.es3892af",
+    "TheGrandVault.es9bdf00",
+    "TheWesternWall.es982124"
   ],
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/10622466053505704856/C32065DDDC3D25094545CC425B831E41575D39FD/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515295/AFB8F257CE1E4973F4C06160A2E156C147AEE1E3/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"CB11\"\n}",
+  "Description": "de Fantasy Flight Games",
   "ContainedObjects_path": "TheDrownedCity-LaCiudadSumergida.980ff0",
   "GUID": "980ff0",
   "Hands": false,
   "HideWhenFaceDown": false,
-  "Name": "Bag",
-  "Nickname": "The Drowned City - La Ciudad Sumergida",
+  "Name": "Custom_Model_Bag",
+  "Nickname": "La Ciudad Sumergida",
   "Transform": {
+    "posX": 41.559,
+    "posY": 1.481,
+    "posZ": -4.106,
+    "rotY": 270,
     "scaleX": 1,
-    "scaleY": 1,
+    "scaleY": 0.14,
     "scaleZ": 1
   }
 }

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/CourtoftheAncients.esb0236f.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/CourtoftheAncients.esb0236f.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/9914798335824707099/8D92AF0BE36BE174F566538D1E5A0B5D2498BD01/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1106\"\n}",
+  "GUID": "esb0236f",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "La Corte de los Antiguos",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/ObsidianCanyons.es5b6dd9.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/ObsidianCanyons.es5b6dd9.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/11516281573803349107/4D31A701ED1589E4AE0FEEA5DEB7E2042846CC5B/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1107\"\n}",
+  "GUID": "es5b6dd9",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "Cañones de Obsidiana",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/OneLastJob.es58c966.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/OneLastJob.es58c966.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/14454194230330299560/335ED02F24E5DB87683D49CF54325B2BE52EAFF1/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1101\"\n}",
+  "GUID": "es58c966",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "Un Último Trabajo",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/SepulchreoftheSleeper.esd832ca.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/SepulchreoftheSleeper.esd832ca.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/9870710312521073925/B7586A10ECF98B918395BCC3879CE9386E6E3F09/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1108\"\n}",
+  "GUID": "esd832ca",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "Sepulcro del Durmiente",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheApiary.es0d2acb.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheApiary.es0d2acb.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/13480001387602275376/E9937F4000C031A7022237B0FA10855EDBC16A59/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1104\"\n}",
+  "GUID": "es0d2acb",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "El Apiario",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheDoomofArkhamPartI.es4ffb65.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheDoomofArkhamPartI.es4ffb65.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/9506910214444977457/8C0EA0AA667EE840F49D3C6CA721BC33DE4F3F87/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1109\"\n}",
+  "GUID": "es4ffb65",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "La Perdición de Arkham Parte I",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheDoomofArkhamPartII.esf4cd9e.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheDoomofArkhamPartII.esf4cd9e.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/16420700942643717371/9617CE083DEAAC973B7032BDE24769391698CF97/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1110\"\n}",
+  "GUID": "esf4cd9e",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "La Perdición de Arkham Parte II",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheDrownedQuarter.es3892af.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheDrownedQuarter.es3892af.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/14037888109303690746/F13E5D2837A8EBDF2D72784D0B5CD41D218AC1DB/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1103\"\n}",
+  "GUID": "es3892af",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "El Barrio Sumergido",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheGrandVault.es9bdf00.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheGrandVault.es9bdf00.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/10687404379908266701/609B27C5E3BDEB9E2C79A92305A8BED5A3A76BF4/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1105\"\n}",
+  "GUID": "es9bdf00",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "La Gran Cámara",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}

--- a/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheWesternWall.es982124.json
+++ b/decomposed/language-pack/Spanish - Campaigns/Spanish-Campaigns.SpanishC/TheDrownedCity-LaCiudadSumergida.980ff0/TheWesternWall.es982124.json
@@ -1,0 +1,51 @@
+{
+  "AttachedDecals": [
+    {
+      "CustomDecal": {
+        "ImageURL": "https://steamusercontent-a.akamaihd.net/ugc/959719855119695911/931B9829687A20F4DEADB36DA57B7E6D76792231/",
+        "Name": "dunwich_back",
+        "Size": 7.4
+      },
+      "Transform": {
+        "posY": -0.1,
+        "rotX": 270,
+        "scaleX": 2,
+        "scaleY": 2,
+        "scaleZ": 2
+      }
+    }
+  ],
+  "ColorDiffuse": {
+    "b": 1,
+    "g": 1,
+    "r": 1
+  },
+  "CustomMesh": {
+    "CustomShader": {
+      "FresnelStrength": 0,
+      "SpecularColor": {
+        "b": 1,
+        "g": 1,
+        "r": 1
+      },
+      "SpecularIntensity": 0,
+      "SpecularSharpness": 2
+    },
+    "DiffuseURL": "https://steamusercontent-a.akamaihd.net/ugc/14488351142771118651/5304095A77C203CADB2AD4AAF2CE638BC693C59F/",
+    "MaterialIndex": 3,
+    "MeshURL": "https://steamusercontent-a.akamaihd.net/ugc/62583916778515333/9F0BE0C211BE3BD1725B4B855F5D3C9C0D020394/",
+    "TypeIndex": 6
+  },
+  "GMNotes": "{\n  \"id\": \"SB1102\"\n}",
+  "GUID": "es982124",
+  "Hands": false,
+  "HideWhenFaceDown": false,
+  "Name": "Custom_Model_Bag",
+  "Nickname": "La Muralla Occidental",
+  "Transform": {
+    "rotY": 270,
+    "scaleX": 2.21,
+    "scaleY": 0.46,
+    "scaleZ": 2.42
+  }
+}


### PR DESCRIPTION
<img width="1554" height="707" alt="Screenshot 2026-09-11 133727" src="https://github.com/user-attachments/assets/674df76b-12e0-4575-a39a-07ef0b7e5618" />
<img width="1868" height="210" alt="Screenshot 2026-09-11 133810" src="https://github.com/user-attachments/assets/f8cb0880-d47d-4a63-af77-e61d836da7d7" />
<img width="1107" height="524" alt="Screenshot 2026-09-11 133858" src="https://github.com/user-attachments/assets/7b67159a-3e36-4727-bbd9-fac70c669bc8" />
<img width="968" height="536" alt="Screenshot 2026-09-11 134039" src="https://github.com/user-attachments/assets/4bda4360-9cb2-446c-85cb-0220990f7aa2" />

